### PR TITLE
Add TLS support and fix concurrency issue while updating struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ This image is configurable using different flags
 | sasl.enabled       | false      | Connect using SASL/PLAIN                             |
 | sasl.username      |            | SASL user name                                       |
 | sasl.password      |            | SASL user password                                   |
+| tls.enabled        | false      | Connect using TLS                                    |
+| tls.rootca         |            | RootCA to verify server the certificate              |
 | topic.filter       | .*         | Regex that determines which topics to collect        |
 | web.listen-address | :9308      | Address to listen on for web interface and telemetry |
 | web.telemetry-path | /metrics   | Path under which to expose metrics                   |


### PR DESCRIPTION
This PR
* adds support for TLS
* fixes an issue which results in `fatal error: concurrent map writes` on brokers with a lot of topics and multiple Prometheus servers scraping the target
* fixes a bug that caused the Sarama client configuration to be overridden
  