### PR TITLE
Update grafana dashboard for kafka_exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Table of Contents
 	-	[Brokers](#brokers)
 	-	[Topics](#topics)
 	-	[Consumer Groups](#consumer-groups)
--	[Grafana Dashboard](#dashboard)	
+-	[Grafana Dashboard](#grafana-dashboard)	
 -   [Contribute](#contribute)
 -   [Donation](#donation)
 -   [License](#license)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Table of Contents
 	-	[Brokers](#brokers)
 	-	[Topics](#topics)
 	-	[Consumer Groups](#consumer-groups)
+-	[Grafana Dashboard](#dashboard)	
 -   [Contribute](#contribute)
 -   [Donation](#donation)
 -   [License](#license)
@@ -211,6 +212,13 @@ kafka_consumergroup_current_offset{consumergroup="KMOffsetCache-kafka-manager-38
 # TYPE kafka_consumergroup_lag gauge
 kafka_consumergroup_lag{consumergroup="KMOffsetCache-kafka-manager-3806276532-ml44w",partition="0",topic="__consumer_offsets"} 1
 ```
+
+Grafana Dashboard
+-------
+
+Grafana Dashboard ID: 7589, name: Kafka Exporter Overview.
+
+For details of the dashboard please see [Kafka Exporter Overview](https://grafana.com/dashboards/7589).
 
 Contribute
 ----------

--- a/kafka_exporter_overview.json
+++ b/kafka_exporter_overview.json
@@ -1,4 +1,34 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS_WH211",
+      "label": "Prometheus_Wh211",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -16,7 +46,8 @@
   "editable": true,
   "gnetId": 721,
   "graphTooltip": 0,
-  "id": 8,
+  "id": null,
+  "iteration": 1534756791145,
   "links": [],
   "panels": [
     {
@@ -24,10 +55,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "${DS_PROMETHEUS_WH211}",
       "fill": 0,
       "gridPos": {
-        "h": 14,
+        "h": 10,
         "w": 10,
         "x": 0,
         "y": 0
@@ -39,7 +70,9 @@
         "current": true,
         "max": true,
         "min": false,
+        "rightSide": false,
         "show": true,
+        "sideWidth": 480,
         "sort": "max",
         "sortDesc": true,
         "total": false,
@@ -59,7 +92,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kafka_topic_partition_current_offset{topic!=\"__consumer_offsets\"}[1m])) by (topic)",
+          "expr": "sum(rate(kafka_topic_partition_current_offset{instance=\"$instance\", topic=~\"$topic\"}[1m])) by (topic)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{topic}}",
@@ -69,7 +102,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Offset per Topic",
+      "title": "Message in per second",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -111,10 +144,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "${DS_PROMETHEUS_WH211}",
       "fill": 0,
       "gridPos": {
-        "h": 14,
+        "h": 10,
         "w": 10,
         "x": 10,
         "y": 0
@@ -128,7 +161,7 @@
         "min": false,
         "rightSide": false,
         "show": true,
-        "sort": "max",
+        "sideWidth": 480,
         "sortDesc": true,
         "total": false,
         "values": true
@@ -147,19 +180,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_consumergroup_lag) by (consumergroup, topic) ",
+          "expr": "sum(kafka_consumergroup_lag{instance=\"$instance\",topic=~\"$topic\"}) by (consumergroup, topic) ",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{topic}} / {{consumergroup}}",
+          "legendFormat": "{{consumergroup}} (topic: {{topic}})",
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Lag per  Topic / Group",
+      "title": "Lag by  Consumer Group",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -198,28 +231,206 @@
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
-      "fill": 1,
+      "datasource": "${DS_PROMETHEUS_WH211}",
+      "fill": 0,
       "gridPos": {
-        "h": 8,
-        "w": 20,
+        "h": 10,
+        "w": 10,
         "x": 0,
-        "y": 14
+        "y": 10
       },
-      "id": 8,
+      "id": 16,
       "legend": {
-        "alignAsTable": false,
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
-        "max": false,
+        "current": true,
+        "max": true,
         "min": false,
         "rightSide": false,
         "show": true,
+        "sideWidth": 480,
         "total": false,
-        "values": false
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(delta(kafka_topic_partition_current_offset{instance=~'$instance', topic=~\"$topic\"}[5m])/5) by (topic)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Message in per minute",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS_WH211}",
+      "fill": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 10,
+        "y": 10
+      },
+      "id": 18,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 480,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(delta(kafka_consumergroup_current_offset{instance=~'$instance',topic=~\"$topic\"}[5m])/5) by (consumergroup, topic)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{consumergroup}} (topic: {{topic}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Message consume per minute",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS_WH211}",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 20,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 420,
+        "total": false,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -235,7 +446,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(topic) (kafka_topic_partitions{topic!=\"__consumer_offsets\"})",
+          "expr": "sum by(topic) (kafka_topic_partitions{instance=\"$instance\",topic=~\"$topic\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{topic}}",
@@ -292,10 +503,71 @@
     "Kafka"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS_WH211}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "label_values(kafka_consumergroup_current_offset, job)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS_WH211}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(kafka_consumergroup_current_offset{job=~\"$job\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS_WH211}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Topic",
+        "multi": true,
+        "name": "topic",
+        "options": [],
+        "query": "label_values(kafka_topic_partition_current_offset{instance='$instance',topic!='__consumer_offsets',topic!='--kafka'}, topic)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "topic",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -326,5 +598,5 @@
   "timezone": "browser",
   "title": "Kafka Exporter Overview",
   "uid": "jwPKIsniz",
-  "version": 27
+  "version": 50
 }


### PR DESCRIPTION
1. Dashboard support multiple kafka_exporter or cluster to monitor.
2. Dashboard support choose one or many topic to monitor.
3. Dashboard add 2 panel for "Message in per minute" and "Message consume per minute".