### PR TITLE
Fix bug where empty/default labels caused panic

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -445,6 +445,7 @@ func main() {
 			splitted := strings.Split(label, "=")
 			if len(splitted) >= 2 {
 				labels[splitted[0]] = splitted[1]
+			}
 		}
 	}
 

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -442,9 +442,9 @@ func main() {
 	// Protect against empty labels
 	if opts.labels != "" {
 		for _, label := range strings.Split(opts.labels, ",") {
-		  splitted := strings.Split(label, "=")
-		  if len(splitted) >= 2 {
-			  labels[splitted[0]] = splitted[1]
+			splitted := strings.Split(label, "=")
+			if len(splitted) >= 2 {
+				labels[splitted[0]] = splitted[1]
 		}
 	}
 

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -424,9 +424,13 @@ func main() {
 	plog.Infoln("Build context", version.BuildContext())
 
 	labels := make(map[string]string)
-	for _, label := range strings.Split(opts.labels, ",") {
-		splitted := strings.Split(label, "=")
-		labels[splitted[0]] = splitted[1]
+
+	// Protect against empty labels
+	if opts.labels != "" {
+		for _, label := range strings.Split(opts.labels, ",") {
+			splitted := strings.Split(label, "=")
+			labels[splitted[0]] = splitted[1]
+		}
 	}
 
 	clusterBrokers = prometheus.NewDesc(


### PR DESCRIPTION
This was caused by the fact that strings.Split(s, sep) will return
[]string{s} when s does not contain sep. Trying to then split a label
on = and assigning those to the labels map caused the resulting panic.