### PR TITLE
Adds metrics:  kafka_consumergroup_current_offset_sum and kafka_consumergroup_lag_sum

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -426,7 +426,9 @@ func main() {
 	labels := make(map[string]string)
 	for _, label := range strings.Split(opts.labels, ",") {
 		splitted := strings.Split(label, "=")
-		labels[splitted[0]] = splitted[1]
+		if len(splitted) >= 2 {
+			labels[splitted[0]] = splitted[1]
+		}
 	}
 
 	clusterBrokers = prometheus.NewDesc(

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -38,7 +38,9 @@ var (
 	topicPartitionUsesPreferredReplica *prometheus.Desc
 	topicUnderReplicatedPartition      *prometheus.Desc
 	consumergroupCurrentOffset         *prometheus.Desc
+	consumergroupCurrentOffsetSum      *prometheus.Desc
 	consumergroupLag                   *prometheus.Desc
+	consumergroupLagSum                *prometheus.Desc
 )
 
 // Exporter collects Kafka stats from the given server and exports them using
@@ -181,7 +183,9 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- topicPartitionUsesPreferredReplica
 	ch <- topicUnderReplicatedPartition
 	ch <- consumergroupCurrentOffset
+	ch <- consumergroupCurrentOffsetSum
 	ch <- consumergroupLag
+	ch <- consumergroupLagSum
 }
 
 // Collect fetches the stats from configured Kafka location and delivers them
@@ -342,15 +346,18 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 						}
 					}
 					if topicConsumed {
+						var currentOffsetSum int64
+						var lagSum int64
 						for partition, offsetFetchResponseBlock := range partitions {
 							err := offsetFetchResponseBlock.Err
 							if err != sarama.ErrNoError {
 								plog.Errorln("Error for  partition %d :%v", partition, err.Error())
 								continue
 							}
-
+							currentOffset := offsetFetchResponseBlock.Offset
+							currentOffsetSum += currentOffset
 							ch <- prometheus.MustNewConstMetric(
-								consumergroupCurrentOffset, prometheus.GaugeValue, float64(offsetFetchResponseBlock.Offset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
+								consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
 							)
 							e.mu.Lock()
 							if offset, ok := offset[topic][partition]; ok {
@@ -361,6 +368,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 									lag = -1
 								} else {
 									lag = offset - offsetFetchResponseBlock.Offset
+									lagSum += lag
 								}
 								ch <- prometheus.MustNewConstMetric(
 									consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
@@ -370,6 +378,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 							}
 							e.mu.Unlock()
 						}
+						ch <- prometheus.MustNewConstMetric(
+							consumergroupCurrentOffsetSum, prometheus.GaugeValue, float64(currentOffsetSum), group.GroupId, topic,
+						)
+						ch <- prometheus.MustNewConstMetric(
+							consumergroupLagSum, prometheus.GaugeValue, float64(lagSum), group.GroupId, topic,
+						)
 					}
 				}
 			}
@@ -488,10 +502,22 @@ func main() {
 		[]string{"consumergroup", "topic", "partition"}, labels,
 	)
 
+	consumergroupCurrentOffsetSum = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "consumergroup", "current_offset_sum"),
+		"Current Offset of a ConsumerGroup at Topic for all partitions",
+		[]string{"consumergroup", "topic"}, labels,
+	)
+
 	consumergroupLag = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "consumergroup", "lag"),
 		"Current Approximate Lag of a ConsumerGroup at Topic/Partition",
 		[]string{"consumergroup", "topic", "partition"}, labels,
+	)
+
+	consumergroupLagSum = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "consumergroup", "lag_sum"),
+		"Current Approximate Lag of a ConsumerGroup at Topic for all partitions",
+		[]string{"consumergroup", "topic"}, labels,
 	)
 
 	if *logSarama {


### PR DESCRIPTION
This adds summed metrics for `kafka_consumergroup_current_offset` and `kafka_consumergroup_lag`.  

Motivation:  When running at scale with high counts of consumer groups and very large partition counts, per-partition metrics can force scaling up prometheus (to potentially undesirable size).  Having a summary allows for scraping full detail where desired, but scraping only the sum as a bellwether where that detail isn't necessary.

Note - this doesn't currently add `-1` with no offset (like the per-partition metric).

Testing:  Validated against kafka locally with multiple topics, consumergroups, partition sizes.

Note:  this includes https://github.com/danielqsj/kafka_exporter/pull/69 since otherwise `master` is broken.