### PR TITLE
sasl.password from env var KAFKA_SASL_PASSWORD

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -480,7 +480,7 @@ func main() {
 	kingpin.Flag("sasl.enabled", "Connect using SASL/PLAIN.").Default("false").BoolVar(&opts.useSASL)
 	kingpin.Flag("sasl.handshake", "Only set this to false if using a non-Kafka SASL proxy.").Default("true").BoolVar(&opts.useSASLHandshake)
 	kingpin.Flag("sasl.username", "SASL user name.").Default("").StringVar(&opts.saslUsername)
-	kingpin.Flag("sasl.password", "SASL user password.").Default("").StringVar(&opts.saslPassword)
+	kingpin.Flag("sasl.password", "SASL user password.").Default("").OverrideDefaultFromEnvar("KAFKA_SASL_PASSWORD").StringVar(&opts.saslPassword)
 	kingpin.Flag("tls.enabled", "Connect using TLS.").Default("false").BoolVar(&opts.useTLS)
 	kingpin.Flag("tls.ca-file", "The optional certificate authority file for TLS client authentication.").Default("").StringVar(&opts.tlsCAFile)
 	kingpin.Flag("tls.cert-file", "The optional certificate file for client authentication.").Default("").StringVar(&opts.tlsCertFile)


### PR DESCRIPTION
Allows users to avoid exposing a password on the command line which is easily accessible by via commands like ps auxf.