### PR TITLE
Set RootCAs to nil in default case.

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -210,12 +210,12 @@ func NewExporter(opts kafkaOpts, topicFilter string, groupFilter string) (*Expor
 
 		config.Net.TLS.Config = &tls.Config{
 			ServerName:         opts.tlsServerName,
-			RootCAs:            x509.NewCertPool(),
 			InsecureSkipVerify: opts.tlsInsecureSkipTLSVerify,
 		}
 
 		if opts.tlsCAFile != "" {
 			if ca, err := ioutil.ReadFile(opts.tlsCAFile); err == nil {
+				config.Net.TLS.Config.RootCAs = x509.NewCertPool()
 				config.Net.TLS.Config.RootCAs.AppendCertsFromPEM(ca)
 			} else {
 				return nil, err


### PR DESCRIPTION
Currently we create an empty CA store, which is not a very useful
default.

The documentation for [cryto/tls#Config](https://godoc.org/crypto/tls#Config) says:

> If RootCAs is nil, TLS uses the host's root CA set.

I want to use this with confluent cloud, that is using certificates
signed by a proper root CA. So loading the system CAs makes everything
work properly just by enabling tls `--tls.enabled`