### PR TITLE
Optimize consumergrouplag

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -424,10 +424,13 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 								// If the topic is consumed by that consumer group, but no offset associated with the partition
 								// forcing lag to -1 to be able to alert on that
 								var lag int64
-								if offsetFetchResponseBlock.Offset == -1 {
+								if currentOffset == -1 {
 									lag = -1
 								} else {
-									lag = offset - offsetFetchResponseBlock.Offset
+									lag = offset - currentOffset
+									if (lag < 0){
+									    lag = 0
+									}
 									lagSum += lag
 								}
 								ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
优化计算consumergrouplag的显示为负的情况1.不应该在收集group offset的时候多次调用，2.如果lag < 0证明此时已经消费完成，不用计算出负值。