### PR TITLE
Add group exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This image is configurable using different flags
 | tls.insecure-skip-tls-verify | false      | If true, the server's certificate will not be checked for validity                                  |
 | topic.filter                 | .*         | Regex that determines which topics to collect                                                       |
 | group.filter                 | .*         | Regex that determines which consumer groups to collect                                              |
+| group.exclude                |            | Regex that determines which consumer groups to exclude                                              |
 | web.listen-address           | :9308      | Address to listen on for web interface and telemetry                                                |
 | web.telemetry-path           | /metrics   | Path under which to expose metrics                                                                  |
 | log.level                    | info       | Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This image is configurable using different flags
 | tls.insecure-skip-tls-verify | false      | If true, the server's certificate will not be checked for validity                                  |
 | topic.filter                 | .*         | Regex that determines which topics to collect                                                       |
 | group.filter                 | .*         | Regex that determines which consumer groups to collect                                              |
-| group.exclude                |            | Regex that determines which consumer groups to exclude                                              |
+| group.exclude                | ^$         | Regex that determines which consumer groups to exclude                                              |
 | web.listen-address           | :9308      | Address to listen on for web interface and telemetry                                                |
 | web.telemetry-path           | /metrics   | Path under which to expose metrics                                                                  |
 | log.level                    | info       | Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] |

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -474,7 +474,7 @@ func main() {
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 		topicFilter   = kingpin.Flag("topic.filter", "Regex that determines which topics to collect.").Default(".*").String()
 		groupFilter   = kingpin.Flag("group.filter", "Regex that determines which consumer groups to collect.").Default(".*").String()
-		groupExclude  = kingpin.Flag("group.exclude", "Regex that determines which consumer groups to exclude.").Default("").String()
+		groupExclude  = kingpin.Flag("group.exclude", "Regex that determines which consumer groups to exclude.").Default("^$").String()
 		logSarama     = kingpin.Flag("log.enable-sarama", "Turn on Sarama logging.").Default("false").Bool()
 
 		opts = kafkaOpts{}


### PR DESCRIPTION
Similar to #104, allows exclusion of consumer groups as regex in golang can't to negative lookaheads and can only act as whitelist and not as a blacklist