### PR TITLE
Add ClientId and ClientHost to consumer group partition metrics

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -399,10 +399,22 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 		for _, group := range describeGroups.Groups {
+			topicPartitionAssignments := make(map[string]map[int32]*sarama.GroupMemberDescription)
 			offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: 1}
 			for topic, partitions := range offset {
+				topicPartitionAssignments[topic] = make(map[int32]*sarama.GroupMemberDescription)
 				for partition := range partitions {
 					offsetFetchRequest.AddPartition(topic, partition)
+				}
+			}
+			for _, member := range group.Members {
+				assignment, err := member.GetMemberAssignment()
+				if err == nil {
+					for topic, partitions := range assignment.Topics {
+						for _, partition := range partitions {
+							topicPartitionAssignments[topic][partition] = member
+						}
+					}
 				}
 			}
 			ch <- prometheus.MustNewConstMetric(
@@ -430,10 +442,16 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 								plog.Errorf("Error for  partition %d :%v", partition, err.Error())
 								continue
 							}
+							var clientId = ""
+							var clientHost = ""
+							if assignedMember, hasMember := topicPartitionAssignments[topic][partition]; hasMember {
+								clientId = assignedMember.ClientId
+								clientHost = assignedMember.ClientHost
+							}
 							currentOffset := offsetFetchResponseBlock.Offset
 							currentOffsetSum += currentOffset
 							ch <- prometheus.MustNewConstMetric(
-								consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
+								consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10), clientId, clientHost,
 							)
 							e.mu.Lock()
 							if offset, ok := offset[topic][partition]; ok {
@@ -447,7 +465,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 									lagSum += lag
 								}
 								ch <- prometheus.MustNewConstMetric(
-									consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
+									consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10), clientId, clientHost,
 								)
 							} else {
 								plog.Errorf("No offset of topic %s partition %d, cannot get consumer group lag", topic, partition)
@@ -583,7 +601,7 @@ func main() {
 	consumergroupCurrentOffset = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "consumergroup", "current_offset"),
 		"Current Offset of a ConsumerGroup at Topic/Partition",
-		[]string{"consumergroup", "topic", "partition"}, labels,
+		[]string{"consumergroup", "topic", "partition", "client_id", "client_host"}, labels,
 	)
 
 	consumergroupCurrentOffsetSum = prometheus.NewDesc(
@@ -595,7 +613,7 @@ func main() {
 	consumergroupLag = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "consumergroup", "lag"),
 		"Current Approximate Lag of a ConsumerGroup at Topic/Partition",
-		[]string{"consumergroup", "topic", "partition"}, labels,
+		[]string{"consumergroup", "topic", "partition", "client_id", "client_host"}, labels,
 	)
 
 	consumergroupLagZookeeper = prometheus.NewDesc(


### PR DESCRIPTION
This PR adds the Client ID and Client Host to the `kafka_consumergroup_current_offset` and `kafka_consumergroup_lag` metrics, which describe the group member (if any) assigned to the particular partition.

```prometheus
kafka_consumergroup_current_offset{client_host="/1.2.3.4",client_id="my.consumer.2",consumergroup="log_ingestion",partition="11",topic="logs"} 1.1231975e+07

kafka_consumergroup_lag{client_host="/1.2.3.1",client_id="my.consumer.1",consumergroup="log_ingestion",partition="4",topic="logs"} 0
```