### PR TITLE
Helm fixes and feature update

### DIFF
--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -28,6 +28,12 @@ spec:
             {{- range .Values.kafkaExporter.kafka.servers }}
             - "--kafka.server={{ . }}"
             {{- end }}
+            {{- range .Values.kafkaExporter.zookeeper.servers }}
+            - "--zookeeper.server={{ . }}"
+            {{- end }}
+            {{- range .Values.kafkaExporter.additionalFlags }}
+            - "{{ . }}"
+            {{- end }}
             {{- if .Values.kafkaExporter.kafka.version }}
             - --kafka.version={{ .Values.kafkaExporter.kafka.version }}
             {{- end }}

--- a/charts/kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/kafka-exporter/templates/servicemonitor.yaml
@@ -19,6 +19,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "kafka-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       helm.sh/chart: {{ include "kafka-exporter.chart" . }}
   namespaceSelector:
     matchNames:

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -19,8 +19,10 @@ service:
 kafkaExporter:
   kafka:
     servers: []
-      # - kafka:9092
-    # version: "1.0.0"
+  zookeeper:
+    servers: []
+  additionalFlags: []
+    # - --use.consumelag.zookeeper
 
   sasl:
     enabled: false


### PR DESCRIPTION
1. Adding zookeeper endpoints option in helmchart

 2. Adding additional flags can be given via
 values.yaml for eg:
 ``` kafkaExporter:
  zookeeper:
    servers:
      - kafka-1-cp-zookeeper.kafka-1.svc.cluster.local:2181
  kafka:
    servers:
      - kafka-1-cp-kafka.kafka-1.svc.cluster.local:9092
  additionalFlags:
    - --use.consumelag.zookeeper

 ```

3. If you install multiple instances of exporter to monitor multiple kafka
clusters, each serviceMonitor will scrape all instances regardless of the
different installation name. for eg:
``` helm install kafka-exporter-cluster1 ./kafka-exporter helm install
kafka-exporter-cluster2 ./kafka-exporter
``` because the instance name, in this case the installation name, is the
only differentiator in these installations are absent in the serviceMonitor
selector, serviceMonitor will all instances.