### PR TITLE
add ability to exclude topics/groups via regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,17 @@ This image is configurable using different flags
 | sasl.handshake               | true       | Only set this to false if using a non-Kafka SASL proxy                                              |
 | sasl.username                |            | SASL user name                                                                                      |
 | sasl.password                |            | SASL user password                                                                                  |
-| sasl.mechanism               |            | SASL mechanism can be plain, scram-sha512, scram-sha256
+| sasl.mechanism               |            | SASL mechanism can be plain, scram-sha512, scram-sha256                                             |
 | tls.enabled                  | false      | Connect using TLS                                                                                   |
 | tls.ca-file                  |            | The optional certificate authority file for TLS client authentication                               |
 | tls.cert-file                |            | The optional certificate file for client authentication                                             |
 | tls.key-file                 |            | The optional key file for client authentication                                                     |
 | tls.insecure-skip-tls-verify | false      | If true, the server's certificate will not be checked for validity                                  |
 | topic.filter                 | .*         | Regex that determines which topics to collect                                                       |
+| topic.excludefilter          |            | Regex that determines which topics to exclude                                                       |
 | group.filter                 | .*         | Regex that determines which consumer groups to collect                                              |
+| group.excludefilter          |            | Regex that determines which consumer groups exclude                                                 |
+
 | web.listen-address           | :9308      | Address to listen on for web interface and telemetry                                                |
 | web.telemetry-path           | /metrics   | Path under which to expose metrics                                                                  |
 | log.level                    | info       | Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] |


### PR DESCRIPTION
I've added the ability to exclude topics/groups via an additional regex as go's regex can't do negative lookarounds