### PR TITLE
Add labels on everything

### DIFF
--- a/charts/kafka-exporter/Chart.yaml
+++ b/charts/kafka-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kafka-exporter
-version: 1.0.0
+version: 1.1.0
 home: https://github.com/abhishekjiitr/kafka-exporter-helm
 maintainers:
   - name: abhishekjiitr

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "kafka-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{ .Values.labels | toYaml | nindent 4 -}}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,6 +21,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kafka-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels -}}
+        {{ .Values.podLabels | toYaml | nindent 8 -}}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/kafka-exporter/templates/secret.yaml
+++ b/charts/kafka-exporter/templates/secret.yaml
@@ -8,6 +8,9 @@ metadata:
     helm.sh/chart: {{ include "kafka-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{- .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
 data:
   ca-file: {{ .Values.kafkaExporter.tls.caFile | b64enc }}
   cert-file: {{ .Values.kafkaExporter.tls.certFile | b64enc }}

--- a/charts/kafka-exporter/templates/service.yaml
+++ b/charts/kafka-exporter/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "kafka-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{ .Values.labels | toYaml | nindent 4 -}}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/kafka-exporter/templates/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     helm.sh/chart: {{ include "kafka-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{ .Values.labels | toYaml | nindent 4 -}}
+    {{- end }}
     {{- if .Values.prometheus.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.prometheus.serviceMonitor.additionalLabels | indent 4 -}}
     {{- end }}

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -47,6 +47,8 @@ prometheus:
     additionalLabels:
       app: kafka-exporter
 
+labels: {}
+podLabels: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR suggest amending the chart to allow adding configurable labels on every object.

Specifically it allows adding:

- Common labels to every top-level object
- Pod labels to the pods in the deployment

This is useful for our use-case where we have cluster-global alerting rules to detect things like crashloop backoff. In my specific case, I want to avoid alerting on this specific deployment while I try it out while it sits in a production namespace.