### PR TITLE
fix: liveness and readiness probes added to k8s specs

### DIFF
--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -56,6 +56,27 @@ spec:
             - name: metrics
               containerPort: 9308
               protocol: TCP
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 9
+          readinessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 3
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 9
+
           {{- if .Values.kafkaExporter.tls.enabled }}
           volumeMounts:
           - name: tls-certs

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -637,6 +637,10 @@ func main() {
 	        </body>
 	        </html>`))
 	})
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		// need more specific sarama check
+		w.Write([]byte("ok"))
+	})
 
 	plog.Infoln("Listening on", *listenAddress)
 	plog.Fatal(http.ListenAndServe(*listenAddress, nil))


### PR DESCRIPTION
fixes #200 

Adding probes helps us restart exporter before it stop respond to prometheus (see #193 )

I've set `timeoutSeconds` as 9 seconds, because default timeout for scrapers in prometheus is 10 seconds