### PR TITLE
fix "invalid sasl mechanism" error occuring in version 1.3.0

### DIFF
--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
             {{- end }}
             - --sasl.username={{ .Values.kafkaExporter.sasl.username }}
             - --sasl.password={{ .Values.kafkaExporter.sasl.password }}
+            - --sasl.mechanism={{ .Values.kafkaExporter.sasl.mechanism }}
             {{- end }}
             {{- if .Values.kafkaExporter.tls.enabled}}
             - --tls.enabled

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -27,6 +27,7 @@ kafkaExporter:
     handshake: true
     username: ""
     password: ""
+    mechanism: ""
 
   tls:
     enabled: false


### PR DESCRIPTION
Getting the following error when installing version 1.3.0 with helm
```
time="2021-04-20T05:32:27Z" level=info msg="Starting kafka_exporter (version=, branch=, revision=)" source="kafka_exporter.go:517"
time="2021-04-20T05:32:27Z" level=info msg="Build context (go=go1.16, user=, date=)" source="kafka_exporter.go:518"
time="2021-04-20T05:32:27Z" level=fatal msg="invalid sasl mechanism \"\": can only be \"scram-sha256\", \"scram-sha512\" or \"plain\"" source="kafka_exporter.go:140"
```

This PR fixes this issue by adding support for specifying `sasl.mechanism` when installing this with helm chart. 