### PR TITLE
Make fetching partition metric concurrently

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -276,92 +276,96 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			offset[topic] = make(map[int32]int64, len(partitions))
 			e.mu.Unlock()
 			for _, partition := range partitions {
-				broker, err := e.client.Leader(topic, partition)
-				if err != nil {
-					plog.Errorf("Cannot get leader of topic %s partition %d: %v", topic, partition, err)
-				} else {
-					ch <- prometheus.MustNewConstMetric(
-						topicPartitionLeader, prometheus.GaugeValue, float64(broker.ID()), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				currentOffset, err := e.client.GetOffset(topic, partition, sarama.OffsetNewest)
-				if err != nil {
-					plog.Errorf("Cannot get current offset of topic %s partition %d: %v", topic, partition, err)
-				} else {
-					e.mu.Lock()
-					offset[topic][partition] = currentOffset
-					e.mu.Unlock()
-					ch <- prometheus.MustNewConstMetric(
-						topicCurrentOffset, prometheus.GaugeValue, float64(currentOffset), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				oldestOffset, err := e.client.GetOffset(topic, partition, sarama.OffsetOldest)
-				if err != nil {
-					plog.Errorf("Cannot get oldest offset of topic %s partition %d: %v", topic, partition, err)
-				} else {
-					ch <- prometheus.MustNewConstMetric(
-						topicOldestOffset, prometheus.GaugeValue, float64(oldestOffset), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				replicas, err := e.client.Replicas(topic, partition)
-				if err != nil {
-					plog.Errorf("Cannot get replicas of topic %s partition %d: %v", topic, partition, err)
-				} else {
-					ch <- prometheus.MustNewConstMetric(
-						topicPartitionReplicas, prometheus.GaugeValue, float64(len(replicas)), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				inSyncReplicas, err := e.client.InSyncReplicas(topic, partition)
-				if err != nil {
-					plog.Errorf("Cannot get in-sync replicas of topic %s partition %d: %v", topic, partition, err)
-				} else {
-					ch <- prometheus.MustNewConstMetric(
-						topicPartitionInSyncReplicas, prometheus.GaugeValue, float64(len(inSyncReplicas)), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				if broker != nil && replicas != nil && len(replicas) > 0 && broker.ID() == replicas[0] {
-					ch <- prometheus.MustNewConstMetric(
-						topicPartitionUsesPreferredReplica, prometheus.GaugeValue, float64(1), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				} else {
-					ch <- prometheus.MustNewConstMetric(
-						topicPartitionUsesPreferredReplica, prometheus.GaugeValue, float64(0), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				if replicas != nil && inSyncReplicas != nil && len(inSyncReplicas) < len(replicas) {
-					ch <- prometheus.MustNewConstMetric(
-						topicUnderReplicatedPartition, prometheus.GaugeValue, float64(1), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				} else {
-					ch <- prometheus.MustNewConstMetric(
-						topicUnderReplicatedPartition, prometheus.GaugeValue, float64(0), topic, strconv.FormatInt(int64(partition), 10),
-					)
-				}
-
-				if e.useZooKeeperLag {
-					ConsumerGroups, err := e.zookeeperClient.Consumergroups()
-
+				wg.Add(1)
+				go func(partition int32) {
+					defer wg.Done()
+					broker, err := e.client.Leader(topic, partition)
 					if err != nil {
-						plog.Errorf("Cannot get consumer group %v", err)
+						plog.Errorf("Cannot get leader of topic %s partition %d: %v", topic, partition, err)
+					} else {
+						ch <- prometheus.MustNewConstMetric(
+							topicPartitionLeader, prometheus.GaugeValue, float64(broker.ID()), topic, strconv.FormatInt(int64(partition), 10),
+						)
 					}
 
-					for _, group := range ConsumerGroups {
-						offset, _ := group.FetchOffset(topic, partition)
-						if offset > 0 {
+					currentOffset, err := e.client.GetOffset(topic, partition, sarama.OffsetNewest)
+					if err != nil {
+						plog.Errorf("Cannot get current offset of topic %s partition %d: %v", topic, partition, err)
+					} else {
+						e.mu.Lock()
+						offset[topic][partition] = currentOffset
+						e.mu.Unlock()
+						ch <- prometheus.MustNewConstMetric(
+							topicCurrentOffset, prometheus.GaugeValue, float64(currentOffset), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					}
 
-							consumerGroupLag := currentOffset - offset
-							ch <- prometheus.MustNewConstMetric(
-								consumergroupLagZookeeper, prometheus.GaugeValue, float64(consumerGroupLag), group.Name, topic, strconv.FormatInt(int64(partition), 10),
-							)
+					oldestOffset, err := e.client.GetOffset(topic, partition, sarama.OffsetOldest)
+					if err != nil {
+						plog.Errorf("Cannot get oldest offset of topic %s partition %d: %v", topic, partition, err)
+					} else {
+						ch <- prometheus.MustNewConstMetric(
+							topicOldestOffset, prometheus.GaugeValue, float64(oldestOffset), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					}
+
+					replicas, err := e.client.Replicas(topic, partition)
+					if err != nil {
+						plog.Errorf("Cannot get replicas of topic %s partition %d: %v", topic, partition, err)
+					} else {
+						ch <- prometheus.MustNewConstMetric(
+							topicPartitionReplicas, prometheus.GaugeValue, float64(len(replicas)), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					}
+
+					inSyncReplicas, err := e.client.InSyncReplicas(topic, partition)
+					if err != nil {
+						plog.Errorf("Cannot get in-sync replicas of topic %s partition %d: %v", topic, partition, err)
+					} else {
+						ch <- prometheus.MustNewConstMetric(
+							topicPartitionInSyncReplicas, prometheus.GaugeValue, float64(len(inSyncReplicas)), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					}
+
+					if broker != nil && replicas != nil && len(replicas) > 0 && broker.ID() == replicas[0] {
+						ch <- prometheus.MustNewConstMetric(
+							topicPartitionUsesPreferredReplica, prometheus.GaugeValue, float64(1), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					} else {
+						ch <- prometheus.MustNewConstMetric(
+							topicPartitionUsesPreferredReplica, prometheus.GaugeValue, float64(0), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					}
+
+					if replicas != nil && inSyncReplicas != nil && len(inSyncReplicas) < len(replicas) {
+						ch <- prometheus.MustNewConstMetric(
+							topicUnderReplicatedPartition, prometheus.GaugeValue, float64(1), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					} else {
+						ch <- prometheus.MustNewConstMetric(
+							topicUnderReplicatedPartition, prometheus.GaugeValue, float64(0), topic, strconv.FormatInt(int64(partition), 10),
+						)
+					}
+
+					if e.useZooKeeperLag {
+						ConsumerGroups, err := e.zookeeperClient.Consumergroups()
+
+						if err != nil {
+							plog.Errorf("Cannot get consumer group %v", err)
+						}
+
+						for _, group := range ConsumerGroups {
+							offset, _ := group.FetchOffset(topic, partition)
+							if offset > 0 {
+
+								consumerGroupLag := currentOffset - offset
+								ch <- prometheus.MustNewConstMetric(
+									consumergroupLagZookeeper, prometheus.GaugeValue, float64(consumerGroupLag), group.Name, topic, strconv.FormatInt(int64(partition), 10),
+								)
+							}
 						}
 					}
-				}
+				}(partition)
 			}
 		}
 	}


### PR DESCRIPTION
When the latency is high between client and broker, fetching multiple partitions metrics makes the latency even worse, because the method is blocked.

I did a test, get current offset request takes 400 ms, I have 3 topics each topic has 60 partitions. It takes 48s to return the metric.
```
$ time curl -s localhost:9308/metrics > /dev/null  

0.00s user
0.01s system
0% cpu 48.241 total
```
after this patch, lag is down to 10s
```
$ time curl -s localhost:9308/metrics  > /dev/null  

0.00s user
0.01s system 
0% cpu 9.663 total
```