### PR TITLE
Add Kustomize Support

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-exporter
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: kafka-exporter
+        imagePullPolicy: IfNotPresent
+        image: danielqsj/kafka-exporter
+        ports:
+        - name: http-metrics
+          containerPort: 9308
+          protocol: TCP

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# ----------------------------------------------------
+# apiVersion and kind of Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: kafka-exporter
+
+resources:
+- deployment.yaml
+- service.yaml
+
+images:
+- name: danielqsj/kafka-exporter
+  newTag: latest

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-exporter
+spec:
+  ports:
+  - name: http-metrics
+    port: 80
+    protocol: TCP
+    targetPort: 9308


### PR DESCRIPTION
Signed-off-by: Weifeng Wang <qclaogui@gmail.com>

# Add Kustomize Support

## Kustomize background

[Kustomize](https://kustomize.io) is a CNCF project that is a part of Kubernetes.  It's included in
the `kubectl` in order to allow users to customize their configurations without introducing templates.


## Usage

kustomize encourages defining multiple variants - e.g. dev, staging and prod, as overlays on a common base.

It’s possible to create an additional overlay to compose these variants together - just declare the overlays as the bases of a new kustomization.

`deploy/base` provides a common base for `kafka_exporter` deploy to Kubernetes. People should [Create variants using overlays](https://github.com/kubernetes-sigs/kustomize#2-create-variants-using-overlays) to deploy in their own environment.

> An overlay is just another kustomization, referring to the base, and referring to patches to apply to that base.
 This arrangement makes it easy to manage your configuration with git. The base could have files from an upstream repository managed by someone else. The overlays could be in a repository you own. Arranging the repo clones as siblings on disk avoids the need for git submodules (though that works fine, if you are a submodule fan).
