### PR TITLE
Allow to skip certificate verification when tls is enabled

### DIFF
--- a/charts/kafka-exporter/Chart.yaml
+++ b/charts/kafka-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kafka-exporter
-version: 1.1.0
+version: 1.1.1
 home: https://github.com/abhishekjiitr/kafka-exporter-helm
 maintainers:
   - name: abhishekjiitr

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -49,9 +49,13 @@ spec:
             {{- end }}
             {{- if .Values.kafkaExporter.tls.enabled}}
             - --tls.enabled
+            {{- if .Values.kafkaExporter.tls.insecureSkipTlsVerify}}
+            - --tls.insecure-skip-tls-verify
+            {{- else }}
             - --tls.ca-file=/etc/tls-certs/ca-file
             - --tls.cert-file=/etc/tls-certs/cert-file
             - --tls.key-file=/etc/tls-certs/key-file
+            {{- end }}
             {{- end }}
             {{- if .Values.kafkaExporter.log }}
             - --log.level={{ .Values.kafkaExporter.log.level }}
@@ -84,7 +88,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 9
 
-          {{- if .Values.kafkaExporter.tls.enabled }}
+          {{- if and .Values.kafkaExporter.tls.enabled (not .Values.kafkaExporter.tls.insecureSkipTlsVerify) }}
           volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs/"
@@ -105,7 +109,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.kafkaExporter.tls.enabled }}
+    {{- if and .Values.kafkaExporter.tls.enabled (not .Values.kafkaExporter.tls.insecureSkipTlsVerify) }}
       volumes:
       - name: tls-certs
         secret:

--- a/charts/kafka-exporter/templates/secret.yaml
+++ b/charts/kafka-exporter/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafkaExporter.tls.enabled }}
+{{- if and .Values.kafkaExporter.tls.enabled (not .Values.kafkaExporter.tls.insecureSkipTlsVerify) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/kafka-exporter/templates/servicemonitor.yaml
@@ -32,4 +32,8 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
     {{- end }}
-{{- end }}
+    {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -31,7 +31,7 @@ kafkaExporter:
 
   tls:
     enabled: false
-    insecure-skip-tls-verify: false
+    insecureSkipTlsVerify: false
     caFile: ""
     certFile: ""
     keyFile: ""
@@ -47,6 +47,7 @@ prometheus:
     interval: "30s"
     additionalLabels:
       app: kafka-exporter
+    metricRelabelings: {}
 
 labels: {}
 podLabels: {}


### PR DESCRIPTION
Hi!

The option `insecureSkipTlsVerify` was not being used in the helm chart, and the `secrets` and respective `volumeMounts` were being rendered the same.
In order to connect, for example, to an Azure Event Hub with kafka interface, I need to use TLS but I want to skip the certificate validation.

I've also added a new field `metricRelabelings` in the `serviceMonitor`, which allow us, for instance, to use HPA in different namespaces from where we're running the exporter, changing the namespace label,.

Ex. changing the namespace `monitoring` to `core`, where the apps are using the HPA:
```
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: kafka-exporter-core
spec:
  releaseName: kafka-exporter-core
  chart:
    spec:
      chart: kafka-exporter
      sourceRef:
        kind: GitRepository
        name: kafka-exporter
        namespace: flux-system
  interval: 1h0m0s
  values:
    nameOverride: kafka-exporter-core
    prometheus:
      serviceMonitor:
        additionalLabels:
          tier: cluster
        metricRelabelings:
        - sourceLabels: [ namespace ]
          regex: '(.*)'
          replacement: core
          targetLabel: namespace
```

Thanks!

Signed-off-by: Marco Amador <amador.marco@gmail.com>