### PR TITLE
Enable building multi-arch docker images for s390x

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.*
 vendor
 Dockerfile
 Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,25 @@
 sudo: required
 
-services:
-- docker
-
 language: go
 
 go:
 - 1.16
 
+env:
+- GOFLAGS="-mod=readonly"
+
+before_install:
+  - sudo rm -rf /var/lib/apt/lists/*
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - mkdir -vp ~/.docker/cli-plugins/
+  - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+
 after_success:
 - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  make docker;
   make push;
   fi
 - if [[ -n "$TRAVIS_TAG" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM        quay.io/prometheus/busybox:latest
 MAINTAINER  Daniel Qian <qsj.daniel@gmail.com>
 
-COPY kafka_exporter /bin/kafka_exporter
+ARG TARGETARCH
+ARG BIN_DIR=.build/linux-${TARGETARCH}/
+
+COPY ${BIN_DIR}/kafka_exporter /bin/kafka_exporter
 
 EXPOSE     9308
 ENTRYPOINT [ "/bin/kafka_exporter" ]


### PR DESCRIPTION
This PR aims at enabling building multi-arch Docker images for CI and also publishing them. The `make docker` target could still produce the same local image as the current master branch, only the `make push` target is modified into building and publishing multi-arch images with `buildx` using cross-built binaries. Currently, only s390x is added to the target list but it will be straightforward to add other platforms as well.

On a side note, setting `- GOFLAGS="-mod=readonly"` and execute `@$(GO) mod vendor` would make sure the CI would not fail when the module list is outdated.

