### PR TITLE
Add possibility to enable TLS for web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ This image is configurable using different flags
 | tls.key-file                 |                | The optional key file for Kafka client authentication                                                                                        |
 | tls.insecure-skip-tls-verify | false          | If true, the server's certificate will not be checked for validity                                                                     |
 | server.tls.enabled                  | false          | Enable TLS for web server                                                                                                                      |
+| server.tls.mutual-auth-enabled                  | false          | Enable TLS client mutual authentication                                                                                                                      |
+| server.tls.ca-file                |                | The certificate authority file for the web server                                                                                |
 | server.tls.cert-file                |                | The certificate file for the web server                                                                                |
 | server.tls.key-file                 |                | The key file for the web server                                                                                        |
 | topic.filter                 | .*             | Regex that determines which topics to collect                                                                                          |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This image is configurable using different flags
 | sasl.keytab-path             |                | Kerberos keytab file path                                                                                                              |
 | sasl.kerberos-auth-type      |                | Kerberos auth type. Either 'keytabAuth' or 'userAuth'                                                                                  |
 | tls.enabled                  | false          | Connect to Kafka using TLS                                                                                                                      |
+| tls.server-name                  |                | Used to verify the hostname on the returned certificates unless tls.insecure-skip-tls-verify is given. The kafka server's name should be given                                                                  |
 | tls.ca-file                  |                | The optional certificate authority file for Kafka TLS client authentication                                                                  |
 | tls.cert-file                |                | The optional certificate file for Kafka client authentication                                                                                |
 | tls.key-file                 |                | The optional key file for Kafka client authentication                                                                                        |

--- a/README.md
+++ b/README.md
@@ -104,11 +104,14 @@ This image is configurable using different flags
 | sasl.realm                   |                | Kerberos realm                                                                                                                         |
 | sasl.keytab-path             |                | Kerberos keytab file path                                                                                                              |
 | sasl.kerberos-auth-type      |                | Kerberos auth type. Either 'keytabAuth' or 'userAuth'                                                                                  |
-| tls.enabled                  | false          | Connect using TLS                                                                                                                      |
-| tls.ca-file                  |                | The optional certificate authority file for TLS client authentication                                                                  |
-| tls.cert-file                |                | The optional certificate file for client authentication                                                                                |
-| tls.key-file                 |                | The optional key file for client authentication                                                                                        |
+| tls.enabled                  | false          | Connect to Kafka using TLS                                                                                                                      |
+| tls.ca-file                  |                | The optional certificate authority file for Kafka TLS client authentication                                                                  |
+| tls.cert-file                |                | The optional certificate file for Kafka client authentication                                                                                |
+| tls.key-file                 |                | The optional key file for Kafka client authentication                                                                                        |
 | tls.insecure-skip-tls-verify | false          | If true, the server's certificate will not be checked for validity                                                                     |
+| server.tls.enabled                  | false          | Enable TLS for web server                                                                                                                      |
+| server.tls.cert-file                |                | The certificate file for the web server                                                                                |
+| server.tls.key-file                 |                | The key file for the web server                                                                                        |
 | topic.filter                 | .*             | Regex that determines which topics to collect                                                                                          |
 | group.filter                 | .*             | Regex that determines which consumer groups to collect                                                                                 |
 | web.listen-address           | :9308          | Address to listen on for web interface and telemetry                                                                                   |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This image is configurable using different flags
 | Flag name                    | Default        | Description                                                                                                                            |
 |------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | kafka.server                 | kafka:9092     | Addresses (host:port) of Kafka server                                                                                                  |
-| kafka.version                | 1.0.0          | Kafka broker version                                                                                                                   |
+| kafka.version                | 2.0.0          | Kafka broker version                                                                                                                   |
 | sasl.enabled                 | false          | Connect using SASL/PLAIN                                                                                                               |
 | sasl.handshake               | true           | Only set this to false if using a non-Kafka SASL proxy                                                                                 |
 | sasl.username                |                | SASL user name                                                                                                                         |

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -57,11 +57,8 @@ spec:
             - --tls.key-file=/etc/tls-certs/key-file
             {{- end }}
             {{- end }}
-            {{- if .Values.kafkaExporter.log }}
-            - --log.level={{ .Values.kafkaExporter.log.level }}
             {{- if .Values.kafkaExporter.log.enableSarama }}
             - --log.enable-sarama
-            {{- end }}
             {{- end }}
           ports:
             - name: metrics

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -37,7 +37,6 @@ kafkaExporter:
     keyFile: ""
 
   log:
-    level: info
     enableSarama: false
 
 prometheus:

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -79,6 +79,7 @@ type kafkaOpts struct {
 	saslPassword             string
 	saslMechanism            string
 	useTLS                   bool
+	tlsServerName            string
 	tlsCAFile                string
 	tlsCertFile              string
 	tlsKeyFile               string
@@ -194,6 +195,7 @@ func NewExporter(opts kafkaOpts, topicFilter string, groupFilter string) (*Expor
 		config.Net.TLS.Enable = true
 
 		config.Net.TLS.Config = &tls.Config{
+			ServerName:         opts.tlsServerName,
 			RootCAs:            x509.NewCertPool(),
 			InsecureSkipVerify: opts.tlsInsecureSkipTLSVerify,
 		}
@@ -669,6 +671,7 @@ func main() {
 	toFlag("sasl.kerberos-auth-type", "Kerberos auth type. Either 'keytabAuth' or 'userAuth'").Default("").StringVar(&opts.kerberosAuthType)
 	toFlag("sasl.keytab-path", "Kerberos keytab file path").Default("").StringVar(&opts.keyTabPath)
 	toFlag("tls.enabled", "Connect to Kafka using TLS.").Default("false").BoolVar(&opts.useTLS)
+	toFlag("tls.server-name", "Used to verify the hostname on the returned certificates unless tls.insecure-skip-tls-verify is given. The kafka server's name should be given.").Default("").StringVar(&opts.tlsServerName)
 	toFlag("tls.ca-file", "The optional certificate authority file for Kafka TLS client authentication.").Default("").StringVar(&opts.tlsCAFile)
 	toFlag("tls.cert-file", "The optional certificate file for Kafka client authentication.").Default("").StringVar(&opts.tlsCertFile)
 	toFlag("tls.key-file", "The optional key file for Kafka client authentication.").Default("").StringVar(&opts.tlsKeyFile)


### PR DESCRIPTION
Added 3 new configs:
- **server.tls.enabled** - whether to enable TLS for the exporter web server
- **server.tls.mutual-auth-enabled** - whether to enable client mutual auth
- **server.tls.ca-file** - path to server CA
- **server.tls.cert-file** - path to server certificate
- **server.tls.key-file** - path to server key
- **tls.server-name** - Used to verify the hostname on the returned certificates unless tls.insecure-skip-tls-verify is given. The kafka server's name should be given

Addresses https://github.com/danielqsj/kafka_exporter/issues/231

```
I0908 12:10:42.330155       1 kafka_exporter.go:726] Starting kafka_exporter (version=1.4.1, branch=master, revision=b6cb6afe3bc77ff0a7ce556f33f9397e57f9b63b)
I0908 12:10:42.330360       1 kafka_exporter.go:727] Build context (go=go1.17, user=root@44bd083e8c36, date=20210908-11:58:41)
I0908 12:10:42.607666       1 kafka_exporter.go:244] Done Init Clients
I0908 12:10:42.607897       1 kafka_exporter.go:843] Listening on HTTPS :9308
```

@danielqsj, @sam-celer please take a look.