### PR TITLE
helm chart: changed log level to verbosity

### DIFF
--- a/charts/kafka-exporter/Chart.yaml
+++ b/charts/kafka-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kafka-exporter
-version: 1.1.1
+version: 1.2.0
 home: https://github.com/abhishekjiitr/kafka-exporter-helm
 maintainers:
   - name: abhishekjiitr

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.kafkaExporter.log }}
-            - --log.level={{ .Values.kafkaExporter.log.level }}
+            - --verbosity={{ .Values.kafkaExporter.log.verbosity }}
             {{- if .Values.kafkaExporter.log.enableSarama }}
             - --log.enable-sarama
             {{- end }}

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -37,7 +37,7 @@ kafkaExporter:
     keyFile: ""
 
   log:
-    level: info
+    verbosity: 0
     enableSarama: false
 
 prometheus:


### PR DESCRIPTION
Bringing the helm chart up to date with new verbosity flag from: https://github.com/danielqsj/kafka_exporter/commit/c190e87b25321775a4facfaafd0e54ec0442aea5