### PR TITLE
Fix number of workers

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -511,7 +511,11 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 		}
 	}
 
-	N := minx(len(topics)/2, e.topicWorkers)
+	N := len(topics)
+	if N > 1 {
+		N = minx(N/2, e.topicWorkers)
+	}
+
 	for w := 1; w <= N; w++ {
 		go loopTopics(w)
 	}


### PR DESCRIPTION
Changes:
Fixes the following issue - when there is only 1 topic returned in `client.RefreshMetadata()` response, kafka-exporter will be stuck in waiting for the `getTopicMetrics` function which never gets triggered.

Signed-off-by: Kate Chernousova <eachernous@gmail.com>