### PR TITLE
Add broker info metric

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -41,6 +41,7 @@ const (
 
 var (
 	clusterBrokers                     *prometheus.Desc
+	clusterBrokerInfo                  *prometheus.Desc
 	topicPartitions                    *prometheus.Desc
 	topicCurrentOffset                 *prometheus.Desc
 	topicOldestOffset                  *prometheus.Desc
@@ -361,6 +362,11 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		clusterBrokers, prometheus.GaugeValue, float64(len(e.client.Brokers())),
 	)
+	for _, b := range e.client.Brokers() {
+		ch <- prometheus.MustNewConstMetric(
+			clusterBrokerInfo, prometheus.GaugeValue, 1, strconv.Itoa(int(b.ID())), b.Addr(),
+		)
+	}
 
 	offset := make(map[string]map[int32]int64)
 
@@ -782,6 +788,11 @@ func setup(
 		prometheus.BuildFQName(namespace, "", "brokers"),
 		"Number of Brokers in the Kafka Cluster.",
 		nil, labels,
+	)
+	clusterBrokerInfo = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "broker_info"),
+		"Information about the Kafka Broker.",
+		[]string{"id", "address"}, labels,
 	)
 	topicPartitions = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "topic", "partitions"),


### PR DESCRIPTION
Hi,

This PR add broker info metric.

labels: 
- address: broker address
- id: broker id

```
# HELP kafka_broker_info Information about the Kafka Broker.
# TYPE kafka_broker_info gauge
kafka_broker_info{address="192.168.40.197:9092",id="1"} 1
kafka_broker_info{address="192.168.40.198:9092",id="2"} 1
kafka_broker_info{address="192.168.40.199:9092",id="3"} 1
```