### PR TITLE
updating to newer Go verison.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danielqsj/kafka_exporter
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Shopify/sarama v1.29.1


### PR DESCRIPTION
Updating the go version to 1.19 to address [CVE-2022-23806](https://nvd.nist.gov/vuln/detail/CVE-2022-23806).

Made the update on my end and ran the tests locally and they passed.