### PR TITLE
Add Datadog Support for Helm Chart

### DIFF
--- a/charts/kafka-exporter/README.md
+++ b/charts/kafka-exporter/README.md
@@ -1,0 +1,33 @@
+HELM INSTALL
+==============
+
+### Install Basic
+
+```shell
+helm upgrade -i kafka-exporter kafka_exporter/charts/kafka-exporter --namespace=kafka-exporter --create-namespace \
+  --set kafkaExporter.kafka.servers="{kafka1:9092,kafka2:9092,.....}"
+```
+
+### Install with Datadog support
+
+```shell
+helm upgrade -i kafka-exporter kafka_exporter/charts/kafka-exporter --namespace=kafka-exporter --create-namespace \
+  --set kafkaExporter.kafka.servers="{kafka1:9092,kafka2:9092,.....}" \
+  --set datadog.prefix=testing-kafka-cluster \
+  --set datadog.use_datadog=true \
+  --set prometheus.serviceMonitor.enabled=false
+```
+
+Sample Datadog collector installation:
+```shell
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm upgrade -i datadog datadog/datadog --namespace=kafka-exporter \
+  --set datadog.apiKey=<key>  \
+  --set targetSystem=linux \
+  --set datadog.prometheusScrape.enabled=true \
+  --set datadog.prometheusScrape.serviceEndpoints=true
+```
+
+

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -18,6 +18,23 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/{{ .Chart.Name }}.check_names: |
+                ["openmetrics"]
+        ad.datadoghq.com/{{ .Chart.Name }}.init_configs: |
+                [{}]
+        ad.datadoghq.com/{{ .Chart.Name }}.instances: |
+          [
+            {
+              "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics ",
+              "namespace": "{{ .Values.datadog_prefix }}",
+              "metrics": [
+                {"kafka_brokers":"kafka_brokers"},
+                {"kafka_consumergroup_lag":"kafka_consumergroup_lag"},
+                {"kafka_consumergroup_current_offset":"kafka_consumergroup_current_offset"}
+               ]
+            }
+          ]      
       labels:
         app.kubernetes.io/name: {{ include "kafka-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -18,23 +18,21 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      {{- if eq .Values.datadog.use_datadog true }}
       annotations:
         ad.datadoghq.com/{{ .Chart.Name }}.check_names: |
-                ["openmetrics"]
+          ["openmetrics"]
         ad.datadoghq.com/{{ .Chart.Name }}.init_configs: |
-                [{}]
+            [{}]
         ad.datadoghq.com/{{ .Chart.Name }}.instances: |
           [
             {
-              "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics ",
-              "namespace": "{{ .Values.datadog_prefix }}",
-              "metrics": [
-                {"kafka_brokers":"kafka_brokers"},
-                {"kafka_consumergroup_lag":"kafka_consumergroup_lag"},
-                {"kafka_consumergroup_current_offset":"kafka_consumergroup_current_offset"}
-               ]
+              "openmetrics_endpoint": "http://{{ include "kafka-exporter.fullname" . }}:{{ .Values.service.port }}/metrics",
+              "namespace": "{{ .Values.datadog.prefix }}",
+              "metrics": {{ .Values.datadog.metrics | toJson | nindent 16 -}}
             }
-          ]      
+           ]
+      {{- end }}    
       labels:
         app.kubernetes.io/name: {{ include "kafka-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -42,7 +42,7 @@ kafkaExporter:
 
 prometheus:
   serviceMonitor:
-    enabled: true
+    enabled: false
     namespace: monitoring
     interval: "30s"
     additionalLabels:
@@ -51,6 +51,7 @@ prometheus:
 
 labels: {}
 podLabels: {}
+datadog_prefix: this_value_to_be_prefixed_to_every_metric_when_viewed_in_Datadog
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -42,7 +42,7 @@ kafkaExporter:
 
 prometheus:
   serviceMonitor:
-    enabled: false
+    enabled: true
     namespace: monitoring
     interval: "30s"
     additionalLabels:
@@ -51,7 +51,18 @@ prometheus:
 
 labels: {}
 podLabels: {}
-datadog_prefix: this_value_to_be_prefixed_to_every_metric_when_viewed_in_Datadog
+
+# Adds in Datadog annotations needed to scrape the prometheus endpoint.
+# prefix is required. If added, will provide a metric such as test.kafka_brokers.
+# Example metrics below. map metric name to a potential new metric name in dd.
+datadog:
+  use_datadog: false
+  prefix: <dd_prefix>
+  metrics: [
+    {"kafka_brokers": "kafka_brokers"},
+    {"kafka_consumergroup_lag": "kafka_consumergroup_lag"},
+    {"kafka_consumergroup_current_offset": "kafka_consumergroup_current_offset"}
+    ]
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Add support into the helm chart to support scraping of metrics to Datadog. Also added a readme with samples.