### PR TITLE
Add topic and group exclusion parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This image is configurable using different flags
 | server.tls.cert-file                |                | The certificate file for the web server                                                                                |
 | server.tls.key-file                 |                | The key file for the web server                                                                                        |
 | topic.filter                 | .*             | Regex that determines which topics to collect                                                                                          |
-| topic.exclude                | .*             | Regex that determines which topics to exclude                                                                                          |
+| topic.exclude                | ^$             | Regex that determines which topics to exclude                                                                                          |
 | group.filter                 | .*             | Regex that determines which consumer groups to collect                                                                                 |
 | group.exclude                | ^$             | Regex that determines which consumer groups to exclude                                                                                 |
 | web.listen-address           | :9308          | Address to listen on for web interface and telemetry                                                                                   |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This image is configurable using different flags
 | server.tls.key-file                 |                | The key file for the web server                                                                                        |
 | topic.filter                 | .*             | Regex that determines which topics to collect                                                                                          |
 | group.filter                 | .*             | Regex that determines which consumer groups to collect                                                                                 |
+| group.exclude                | ^$             | Regex that determines which consumer groups to exclude                                                                                 |
 | web.listen-address           | :9308          | Address to listen on for web interface and telemetry                                                                                   |
 | web.telemetry-path           | /metrics       | Path under which to expose metrics                                                                                                     |
 | log.enable-sarama            | false          | Turn on Sarama logging                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This image is configurable using different flags
 | server.tls.cert-file                |                | The certificate file for the web server                                                                                |
 | server.tls.key-file                 |                | The key file for the web server                                                                                        |
 | topic.filter                 | .*             | Regex that determines which topics to collect                                                                                          |
+| topic.exclude                | .*             | Regex that determines which topics to exclude                                                                                          |
 | group.filter                 | .*             | Regex that determines which consumer groups to collect                                                                                 |
 | group.exclude                | ^$             | Regex that determines which consumer groups to exclude                                                                                 |
 | web.listen-address           | :9308          | Address to listen on for web interface and telemetry                                                                                   |


### PR DESCRIPTION
Related to #91 #103 #104 #127 #170 #217 and #93 (but solves it a different way that allows for both inclusion and exclusion). These PRs all seem to be out of date and have conflicts, so I took the main implementation from both and included them in this new PR. I'm happy to close and improve old PRs, but it would just be more work at this point.

Hopefully this can finally get some traction and get in since our kafka exporter pods are having a lot of trouble with some canary/health check consumer groups that don't need to be reported.