### PR TITLE
bump go version to 1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.4
+          go-version: '1.21'
       - name: Build Docker Image
         run: make push
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       ## this will contain a matrix of all of the combinations
       ## we wish to test again:
       matrix:
-        go-version: [ 1.20.x ]
+        go-version: [ '1.21' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.4
+          go-version: '1.21'
       - uses: olegtarasov/get-tag@v2.1
         id: tagName
       - name: Release Docker Image

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danielqsj/kafka_exporter
 
-go 1.20
+go 1.21
 
 require (
 	github.com/Shopify/sarama v1.38.1


### PR DESCRIPTION
Bump go version to 1.21 to address CVEs : 
[CVE-2023-29402](https://nvd.nist.gov/vuln/detail/CVE-2023-29402)
[CVE-2023-29404](https://nvd.nist.gov/vuln/detail/CVE-2023-29404)
[CVE-2023-29405](https://nvd.nist.gov/vuln/detail/CVE-2023-29405)
[CVE-2023-39533](https://nvd.nist.gov/vuln/detail/CVE-2023-39533)
[CVE-2023-29403](https://nvd.nist.gov/vuln/detail/CVE-2023-29403)
[CVE-2023-29409](https://nvd.nist.gov/vuln/detail/CVE-2023-29409)
[CVE-2023-29406](https://nvd.nist.gov/vuln/detail/CVE-2023-29406)

Ran tests locally.
before: 
`Vulnerabilities found for image danielqsj/kafka-exporter:latest: total - 7, critical - 3, high - 2, medium - 2, low - 0`
after:
`Vulnerabilities found for image kafka-exporter:bump-go: total - 0, critical - 0, high - 0, medium - 0, low - 0`
