### PR TITLE
Allow for arbitrary annotations in the pod template

### DIFF
--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -18,8 +18,12 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      {{- if eq .Values.datadog.use_datadog true }}
+      {{- if or (eq .Values.datadog.use_datadog true) (.Values.podAnnotations) }}
       annotations:
+        {{- if .Values.podAnnotations }}
+        {{- .Values.podAnnotations | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if eq .Values.datadog.use_datadog true }}
         ad.datadoghq.com/{{ .Chart.Name }}.check_names: |
           ["openmetrics"]
         ad.datadoghq.com/{{ .Chart.Name }}.init_configs: |
@@ -32,6 +36,7 @@ spec:
               "metrics": {{ .Values.datadog.metrics | toJson | nindent 16 -}}
             }
            ]
+        {{- end }}
       {{- end }}    
       labels:
         app.kubernetes.io/name: {{ include "kafka-exporter.name" . }}

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -51,6 +51,7 @@ prometheus:
 
 labels: {}
 podLabels: {}
+podAnnotations: {}
 
 # Adds in Datadog annotations needed to scrape the prometheus endpoint.
 # prefix is required. If added, will provide a metric such as test.kafka_brokers.


### PR DESCRIPTION
The chart currently allows for arbitrary labels to be set in the deployment's pod spec, but only the specific datadog annotations to be set. This change will allow for arbitrary annotations to be configured via values.

This use-case is relevant for me because my company's Prometheus setup discovers scrape targets via Annotation, not via ServiceMonitor.