### PR TITLE
Fix Error Handling in Member Assignment to Ensure Seamless Processing

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -569,10 +569,6 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 			return
 		}
 		for _, group := range describeGroups.Groups {
-			if group.ProtocolType != "consumer" {
-				klog.Warningf("Group '%v' is using a protocol type other than 'consumer'. It may not be compatible with functions relying on consumer group protocols.", group.GroupId)
-				continue
-			}
 			offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: 1}
 			if e.offsetShowAll {
 				for topic, partitions := range offset {
@@ -585,7 +581,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 					assignment, err := member.GetMemberAssignment()
 					if err != nil {
 						klog.Errorf("Cannot get GetMemberAssignment of group member %v : %v", member, err)
-						return
+						continue
 					}
 					for topic, partions := range assignment.Topics {
 						for _, partition := range partions {

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -569,6 +569,10 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 			return
 		}
 		for _, group := range describeGroups.Groups {
+			if group.ProtocolType != "consumer" {
+				klog.Warningf("Group '%v' is using a protocol type other than 'consumer'. It may not be compatible with functions relying on consumer group protocols.", group.GroupId)
+				continue
+			}
 			offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: 1}
 			if e.offsetShowAll {
 				for topic, partitions := range offset {


### PR DESCRIPTION
### Summary
This pull request fixes an issue with error handling in member assignment, ensuring that data processing remains uninterrupted and error-free.

 The code would fail and skip the pending metrics. For example, if the Confluent [Schema Registry created a group named](https://github.com/confluentinc/schema-registry/blob/89c2db0f5c61eb2ea745344f5e9372fe592c5b18/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java#L102) "schema-registry" but used the `protocolType` "sr", it would cause a silent failure, breaking the loop of groups to scrape the metrics.





