### PR TITLE
fix: Fixing Issue with Member Assignments in Consumer Group

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -578,6 +578,10 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 				}
 			} else {
 				for _, member := range group.Members {
+					if len(member.MemberAssignment) == 0 {
+						klog.Warningf("MemberAssignment is empty for group member: %v in group: %v", member.MemberId, group.GroupId)
+						continue
+					}
 					assignment, err := member.GetMemberAssignment()
 					if err != nil {
 						klog.Errorf("Cannot get GetMemberAssignment of group member %v : %v", member, err)


### PR DESCRIPTION
**PR Summary:**

Title: Fixing Issue with Member Assignments in Consumer Group

Description: The code was updated to handle cases where consumer group members do not have any assigned partition-topic (for example in a rebalance). Previously, the code was expecting all assignments to have a value, leading to errors when encountering members without assignments. The fix involved checking if `member.MemberAssignment` is not an empty list before processing the assignment to ensure proper handling of all scenarios within the consumer group.

Example:

Previous Behavior:
- Code expected all member assignments to have a value.
- Errors occurred when encountering consumer group members with no assigned partition-topic.

Fix Implemented:
- Updated code to check if `member.MemberAssignment` is not an empty list.
- Ensured proper handling of cases where assignments are empty for consumer group members.

By incorporating this fix, the code now effectively manages scenarios where consumer group members may not have any assigned partition-topic, preventing errors and enhancing the overall functionality of the system.