### PR TITLE
Adding api group in service monitor for Azure managed prometheus

### DIFF
--- a/charts/kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/kafka-exporter/templates/servicemonitor.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.prometheus.serviceMonitor.enabled }}
+{{- if .Values.azuremanagedprometheus.use_azuremanagedprometheus }}
+apiVersion: azmonitoring.coreos.com/v1
+{{- else }}
 apiVersion: monitoring.coreos.com/v1
+{{- end }}
 kind: ServiceMonitor
 metadata:
   name: {{ include "kafka-exporter.fullname" . }}

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -64,6 +64,10 @@ datadog:
     {"kafka_consumergroup_current_offset": "kafka_consumergroup_current_offset"}
     ]
 
+# Add support for azure managed prometheus by creating service monitor with the supported api group
+azuremanagedprometheus:
+  use_azuremanagedprometheus: false
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Azure managed prometheus supports scraping using service monitor in its own api group azmonitoring.coreos.com/v1 so that it is cleanly isolated from the OSS prometheus operator. Adding support for helm installation to use the right api group for managed prometheus