### PR TITLE
feat: add new metric kafka_consumergroup_topicmembers

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -56,6 +56,7 @@ var (
 	consumergroupLagSum                *prometheus.Desc
 	consumergroupLagZookeeper          *prometheus.Desc
 	consumergroupMembers               *prometheus.Desc
+	consumergroupTopicMembers          *prometheus.Desc
 )
 
 // Exporter collects Kafka stats from the given server and exports them using
@@ -590,9 +591,25 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 					}
 				}
 			}
+
 			ch <- prometheus.MustNewConstMetric(
 				consumergroupMembers, prometheus.GaugeValue, float64(len(group.Members)), group.GroupId,
 			)
+
+			uniqueTopics := make(map[string]int)
+			for _, member := range group.Members {
+				meta, _ := member.GetMemberMetadata()
+				for _, topic := range meta.Topics {
+					uniqueTopics[topic]++
+				}
+			}
+
+			for topic, count := range uniqueTopics {
+				ch <- prometheus.MustNewConstMetric(
+					consumergroupTopicMembers, prometheus.GaugeValue, float64(count), group.GroupId, topic,
+				)
+			}
+
 			offsetFetchResponse, err := broker.FetchOffset(&offsetFetchRequest)
 			if err != nil {
 				klog.Errorf("Cannot get offset of group %s: %v", group.GroupId, err)
@@ -890,6 +907,12 @@ func setup(
 		prometheus.BuildFQName(namespace, "consumergroup", "members"),
 		"Amount of members in a consumer group",
 		[]string{"consumergroup"}, labels,
+	)
+
+	consumergroupTopicMembers = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "consumergroup", "topicmembers"),
+		"Amount of members in a consumer group against a topic",
+		[]string{"consumergroup", "topic"}, labels,
 	)
 
 	if logSarama {


### PR DESCRIPTION
creates a new metric based on kafka_consumergroup_members, but includes the topic name as a label