### PR TITLE
Fix issue#409: skip error group members

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -569,6 +569,10 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 			return
 		}
 		for _, group := range describeGroups.Groups {
+			if group.Err != 0 {
+				klog.Errorf("Cannot describe for the group %s with error code %d", group.GroupId, group.Err)
+				continue
+			}
 			offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: 1}
 			if e.offsetShowAll {
 				for topic, partitions := range offset {


### PR DESCRIPTION
Fix https://github.com/danielqsj/kafka_exporter/issues/409 

GroupDescription structure there are Err/ErrorCode fields, that are not checked by the exporter for errors in the Kafka response. Therefore, the exporter always believes, that the answer is correct, which sometimes leads to collisions in the metric. 

This PR fixes it by checking the error code and log error for code not equal to 0.

The log when describe some groups with error is like this:
```
E0515 15:26:48.895819   37293 kafka_exporter.go:573] Cannot describe for the group console-consumer-57947 with error code 16
```