### PR TITLE
add securityContext to deployment

### DIFF
--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -111,6 +111,8 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       {{- with .Values.nodeSelector }}
 
       nodeSelector:

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -85,3 +85,14 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+securityContext:  
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+  readOnlyRootFilesystem: true
+  runAsGroup: 10000
+  runAsNonRoot: true
+  runAsUser: 10000


### PR DESCRIPTION
Add securityContext with stronger security than the default options. Can be overwritten downstream.