### PR TITLE
fix: incorrect build_info metric introduced in 9df9db85

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -21,11 +21,11 @@ import (
 	"github.com/krallistic/kazoo-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	plog "github.com/prometheus/common/promlog"
 	plogflag "github.com/prometheus/common/promlog/flag"
 
+	versionCollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/common/version"
 	"github.com/rcrowley/go-metrics"
 	"k8s.io/klog/v2"
@@ -707,7 +707,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 
 func init() {
 	metrics.UseNilMetrics = true
-	prometheus.MustRegister(collectors.NewBuildInfoCollector())
+	prometheus.MustRegister(versionCollector.NewCollector("kafka_exporter"))
 }
 
 //func toFlag(name string, help string) *kingpin.FlagClause {


### PR DESCRIPTION
Hi,

After upgrading to the latest version, I found that the `kafka_exporter_build_info` metric was missing.

It was modified in the [9df9db85](https://github.com/danielqsj/kafka_exporter/commit/9df9db8508b54aec8cab5ef75900bf5ad28291b6#diff-72029fbf7c731a44c2384c82a832531ff682926b6934fc65a42e356d37f79fddL690-R691) commit. We should use `versionCollector.NewCollector` instead of `collectors.NewBuildInfoCollector`.