### PR TITLE
Update go version for crossbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: promu
 
 crossbuild: promu
 	@echo ">> crossbuilding binaries"
-	@$(PROMU) crossbuild --go=1.23
+	@$(PROMU) crossbuild --go=1.24
 
 tarball: promu
 	@echo ">> building release tarball"


### PR DESCRIPTION
Update the go version when running crossbuild to 1.24
Using 1.23 introduces 16 CVEs from stdlib:
CVE-2025-22874
CVE-2025-47907
CVE-2025-47912
CVE-2025-58183
CVE-2025-58186
CVE-2025-58187
CVE-2025-58188
CVE-2025-58189
CVE-2025-61723
CVE-2025-61724
CVE-2025-0913
CVE-2025-22871
CVE-2025-4673
CVE-2025-47906
CVE-2025-58185
CVE-2025-61725
