### PR TITLE
add concurrent workers for consumer group metrics collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/danielqsj/kafka_exporter
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/IBM/sarama v1.45.2
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.0
 	github.com/krallistic/kazoo-go v0.0.0-20170526135507-a15279744f4e
+	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.0
 	github.com/prometheus/common v0.55.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
@@ -57,6 +58,7 @@ require (
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
+	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/panjf2000/ants/v2 v2.11.3 h1:AfI0ngBoXJmYOpDh9m516vjqoUu2sLrIVgppI9TZVpg=
+github.com/panjf2000/ants/v2 v2.11.3/go.mod h1:8u92CYMUc6gyvTIw8Ru7Mt7+/ESnJahz5EVtqfrilek=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -616,9 +616,13 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 				continue
 			}
 
-			pool.Submit(func() {
+			err := pool.Submit(func() {
 				e.emitGroupMetrics(group, broker, offset, ch)
 			})
+			if err != nil {
+				klog.Errorf("Cannot submit task to pool: %v", err)
+				return
+			}
 		}
 	}
 

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
 	"github.com/krallistic/kazoo-go"
+	"github.com/panjf2000/ants/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	plog "github.com/prometheus/common/promlog"
@@ -75,11 +76,13 @@ type Exporter struct {
 	metadataRefreshInterval time.Duration
 	offsetShowAll           bool
 	topicWorkers            int
+	groupWorkers            int
 	allowConcurrent         bool
 	sgMutex                 sync.Mutex
 	sgWaitCh                chan struct{}
 	sgChans                 []chan<- prometheus.Metric
 	consumerGroupFetchAll   bool
+	groupMetricsTimeout     time.Duration
 }
 
 type kafkaOpts struct {
@@ -114,9 +117,11 @@ type kafkaOpts struct {
 	kerberosAuthType         string
 	offsetShowAll            bool
 	topicWorkers             int
+	groupWorkers             int
 	allowConcurrent          bool
 	allowAutoTopicCreation   bool
 	verbosityLogLevel        int
+	groupMetricsTimeout      string
 }
 
 type MSKAccessTokenProvider struct {
@@ -267,6 +272,11 @@ func NewExporter(opts kafkaOpts, topicFilter string, topicExclude string, groupF
 		}
 	}
 
+	groupMetricsTimeout, err := time.ParseDuration(opts.groupMetricsTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot parse group metrics timeout: %w", err)
+	}
+
 	interval, err := time.ParseDuration(opts.metadataRefreshInterval)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot parse metadata refresh interval: %w", err)
@@ -295,11 +305,13 @@ func NewExporter(opts kafkaOpts, topicFilter string, topicExclude string, groupF
 		metadataRefreshInterval: interval,
 		offsetShowAll:           opts.offsetShowAll,
 		topicWorkers:            opts.topicWorkers,
+		groupWorkers:            opts.groupWorkers,
 		allowConcurrent:         opts.allowConcurrent,
 		sgMutex:                 sync.Mutex{},
 		sgWaitCh:                nil,
 		sgChans:                 []chan<- prometheus.Metric{},
 		consumerGroupFetchAll:   config.Version.IsAtLeast(sarama.V2_0_0_0),
+		groupMetricsTimeout:     groupMetricsTimeout,
 	}, nil
 }
 
@@ -406,15 +418,19 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 			klog.Errorf("Cannot refresh topics, using cached data: %v", err)
 		}
 
+		klog.V(DEBUG).Infof("Took %v to refresh metadata", time.Since(now))
 		e.nextMetadataRefresh = now.Add(e.metadataRefreshInterval)
 	}
 
+	now = time.Now()
 	topics, err := e.client.Topics()
 	if err != nil {
 		klog.Errorf("Cannot get topics: %v", err)
 		return
 	}
 
+	klog.V(DEBUG).Infof("Took %v to get topics", time.Since(now))
+	klog.V(DEBUG).Infof("Found %v topics", len(topics))
 	topicChannel := make(chan string)
 
 	getTopicMetrics := func(topic string) {
@@ -560,15 +576,22 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 	}
 	close(topicChannel)
 
+	now = time.Now()
 	wg.Wait()
+	klog.V(DEBUG).Infof("Took %v to get topic metrics", time.Since(now))
 
+	pool, err := ants.NewPool(e.groupWorkers)
+	if err != nil {
+		klog.Errorf("Cannot create pool: %v", err)
+		return
+	}
+	// Defer pool release here in case function exits early due to error.
+	// Even though we do another release below, this is fine (double release is a no-op).
+	defer pool.Release()
+
+	// broker should be opened before calling this function
 	getConsumerGroupMetrics := func(broker *sarama.Broker) {
 		defer wg.Done()
-		if err := broker.Open(e.client.Config()); err != nil && err != sarama.ErrAlreadyConnected {
-			klog.Errorf("Cannot connect to broker %d: %v", broker.ID(), err)
-			return
-		}
-		defer broker.Close()
 
 		groups, err := broker.ListGroups(&sarama.ListGroupsRequest{})
 		if err != nil {
@@ -592,98 +615,10 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 				klog.Errorf("Cannot describe for the group %s with error code %d", group.GroupId, group.Err)
 				continue
 			}
-			offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: e.fetchOffsetVersion()}
-			if e.offsetShowAll {
-				for topic, partitions := range offset {
-					for partition := range partitions {
-						offsetFetchRequest.AddPartition(topic, partition)
-					}
-				}
-			} else {
-				for _, member := range group.Members {
-					if len(member.MemberAssignment) == 0 {
-						klog.Warningf("MemberAssignment is empty for group member: %v in group: %v", member.MemberId, group.GroupId)
-						continue
-					}
-					assignment, err := member.GetMemberAssignment()
-					if err != nil {
-						klog.Errorf("Cannot get GetMemberAssignment of group member %v : %v", member, err)
-						continue
-					}
-					for topic, partions := range assignment.Topics {
-						for _, partition := range partions {
-							offsetFetchRequest.AddPartition(topic, partition)
-						}
-					}
-				}
-			}
-			ch <- prometheus.MustNewConstMetric(
-				consumergroupMembers, prometheus.GaugeValue, float64(len(group.Members)), group.GroupId,
-			)
-			offsetFetchResponse, err := broker.FetchOffset(&offsetFetchRequest)
-			if err != nil {
-				klog.Errorf("Cannot get offset of group %s: %v", group.GroupId, err)
-				continue
-			}
 
-			for topic, partitions := range offsetFetchResponse.Blocks {
-				// If the topic is not consumed by that consumer group, skip it
-				topicConsumed := false
-				for _, offsetFetchResponseBlock := range partitions {
-					// Kafka will return -1 if there is no offset associated with a topic-partition under that consumer group
-					if offsetFetchResponseBlock.Offset != -1 {
-						topicConsumed = true
-						break
-					}
-				}
-				if !topicConsumed {
-					continue
-				}
-
-				var currentOffsetSum int64
-				var lagSum int64
-				for partition, offsetFetchResponseBlock := range partitions {
-					err := offsetFetchResponseBlock.Err
-					if err != sarama.ErrNoError {
-						klog.Errorf("Error for  partition %d :%v", partition, err.Error())
-						continue
-					}
-					currentOffset := offsetFetchResponseBlock.Offset
-					currentOffsetSum += currentOffset
-					ch <- prometheus.MustNewConstMetric(
-						consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
-					)
-					e.mu.Lock()
-					currentPartitionOffset, currentPartitionOffsetError := e.client.GetOffset(topic, partition, sarama.OffsetNewest)
-					if currentPartitionOffsetError != nil {
-						klog.Errorf("Cannot get current offset of topic %s partition %d: %v", topic, partition, currentPartitionOffsetError)
-					} else {
-						var lag int64
-						if offsetFetchResponseBlock.Offset == -1 {
-							lag = -1
-						} else {
-							if offset, ok := offset[topic][partition]; ok {
-								if currentPartitionOffset == -1 {
-									currentPartitionOffset = offset
-								}
-							}
-							lag = currentPartitionOffset - offsetFetchResponseBlock.Offset
-							lagSum += lag
-						}
-
-						ch <- prometheus.MustNewConstMetric(
-							consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
-						)
-					}
-					e.mu.Unlock()
-				}
-				ch <- prometheus.MustNewConstMetric(
-					consumergroupCurrentOffsetSum, prometheus.GaugeValue, float64(currentOffsetSum), group.GroupId, topic,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					consumergroupLagSum, prometheus.GaugeValue, float64(lagSum), group.GroupId, topic,
-				)
-			}
+			pool.Submit(func() {
+				e.emitGroupMetrics(group, broker, offset, ch)
+			})
 		}
 	}
 
@@ -707,9 +642,118 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 				}
 			}
 		}
+		now = time.Now()
 		wg.Wait()
+		err = pool.ReleaseTimeout(e.groupMetricsTimeout)
+		if err != nil {
+			klog.Errorf("Failed to release pool: %v", err)
+		}
+
+		klog.V(DEBUG).Infof("Took %v to get consumer group metrics", time.Since(now))
 	} else {
 		klog.Errorln("No valid broker, cannot get consumer group metrics")
+	}
+}
+
+func (e *Exporter) emitGroupMetrics(group *sarama.GroupDescription, broker *sarama.Broker, offsetMap map[string]map[int32]int64, ch chan<- prometheus.Metric) {
+	offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: e.fetchOffsetVersion()}
+	if e.offsetShowAll {
+		for topic, partitions := range offsetMap {
+			for partition := range partitions {
+				offsetFetchRequest.AddPartition(topic, partition)
+			}
+		}
+	} else {
+		for _, member := range group.Members {
+			if len(member.MemberAssignment) == 0 {
+				klog.Warningf("MemberAssignment is empty for group member: %v in group: %v", member.MemberId, group.GroupId)
+				continue
+			}
+			assignment, err := member.GetMemberAssignment()
+			if err != nil {
+				klog.Errorf("Cannot get GetMemberAssignment of group member %v : %v", member, err)
+				continue
+			}
+			for topic, partions := range assignment.Topics {
+				for _, partition := range partions {
+					offsetFetchRequest.AddPartition(topic, partition)
+				}
+			}
+		}
+	}
+	ch <- prometheus.MustNewConstMetric(
+		consumergroupMembers, prometheus.GaugeValue, float64(len(group.Members)), group.GroupId,
+	)
+	// make a copy of the broker since each broker object does not support concurrent requests
+	brokerCopy := sarama.NewBroker(broker.Addr())
+	if err := brokerCopy.Open(e.client.Config()); err != nil {
+		klog.Errorf("Cannot connect to broker %s: %v", brokerCopy.Addr(), err)
+		return
+	}
+	defer brokerCopy.Close()
+	offsetFetchResponse, err := brokerCopy.FetchOffset(&offsetFetchRequest)
+	if err != nil {
+		klog.Errorf("Cannot get offset of group %s: %v", group.GroupId, err)
+		return
+	}
+
+	for topic, partitions := range offsetFetchResponse.Blocks {
+		// If the topic is not consumed by that consumer group, skip it
+		topicConsumed := false
+		for _, offsetFetchResponseBlock := range partitions {
+			// Kafka will return -1 if there is no offset associated with a topic-partition under that consumer group
+			if offsetFetchResponseBlock.Offset != -1 {
+				topicConsumed = true
+				break
+			}
+		}
+		if !topicConsumed {
+			continue
+		}
+
+		var currentOffsetSum int64
+		var lagSum int64
+		for partition, offsetFetchResponseBlock := range partitions {
+			err := offsetFetchResponseBlock.Err
+			if err != sarama.ErrNoError {
+				klog.Errorf("Error for  partition %d :%v", partition, err.Error())
+				continue
+			}
+			currentOffset := offsetFetchResponseBlock.Offset
+			currentOffsetSum += currentOffset
+			ch <- prometheus.MustNewConstMetric(
+				consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
+			)
+			currentPartitionOffset, currentPartitionOffsetError := e.client.GetOffset(topic, partition, sarama.OffsetNewest)
+			if currentPartitionOffsetError != nil {
+				klog.Errorf("Cannot get current offset of topic %s partition %d: %v", topic, partition, currentPartitionOffsetError)
+			} else {
+				var lag int64
+				if offsetFetchResponseBlock.Offset == -1 {
+					lag = -1
+				} else {
+					// writes to the offset map are only performed in getTopicMetrics(), which is guaranteed to be done before this point
+					// no mutex required for concurrent reads
+					if offset, ok := offsetMap[topic][partition]; ok {
+						if currentPartitionOffset == -1 {
+							currentPartitionOffset = offset
+						}
+					}
+					lag = currentPartitionOffset - offsetFetchResponseBlock.Offset
+					lagSum += lag
+				}
+
+				ch <- prometheus.MustNewConstMetric(
+					consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
+				)
+			}
+		}
+		ch <- prometheus.MustNewConstMetric(
+			consumergroupCurrentOffsetSum, prometheus.GaugeValue, float64(currentOffsetSum), group.GroupId, topic,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			consumergroupLagSum, prometheus.GaugeValue, float64(lagSum), group.GroupId, topic,
+		)
 	}
 }
 
@@ -799,8 +843,10 @@ func main() {
 	toFlagBoolVar("offset.show-all", "Whether show the offset/lag for all consumer group, otherwise, only show connected consumer groups, default is true", true, "true", &opts.offsetShowAll)
 	toFlagBoolVar("concurrent.enable", "If true, all scrapes will trigger kafka operations otherwise, they will share results. WARN: This should be disabled on large clusters. Default is false", false, "false", &opts.allowConcurrent)
 	toFlagIntVar("topic.workers", "Number of topic workers", 100, "100", &opts.topicWorkers)
+	toFlagIntVar("group.workers", "Number of consumer group workers", 100, "100", &opts.groupWorkers)
 	toFlagBoolVar("kafka.allow-auto-topic-creation", "If true, the broker may auto-create topics that we requested which do not already exist, default is false.", false, "false", &opts.allowAutoTopicCreation)
 	toFlagIntVar("verbosity", "Verbosity log level", 0, "0", &opts.verbosityLogLevel)
+	toFlagStringVar("group.metrics.timeout", "Timeout for emitting consumer group metrics", "5m", &opts.groupMetricsTimeout)
 
 	plConfig := plog.Config{}
 	plogflag.AddFlags(kingpin.CommandLine, &plConfig)


### PR DESCRIPTION
This PR speeds up consumer group metric collection, which can be very slow for large kafka clusters.

changes:
1. Add `--group.workers` (default is 100) and `--group.metrics.timeout` (default is 5m). Instead of collecting metrics for each consumer group serially for each broker, use a separate goroutine for each group.
2. For each consumer group, make a copy of the broker object before calling FetchOffset since each broker object does not support concurrent requests.
3. Remove an unnecessary mutex lock that was happening for each partition of each topic.
4. Add some debug logging for execution time details

**Results on a test cluster**
Before: 2 minutes to collect consumer group metrics
After: 14 seconds to collect consumer group metrics