### PR TITLE
feat: add sasl.oauthbearer-scopes parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This image is configurable using different flags
 | sasl.mechanism                 | plain          | SASL SCRAM SHA algorithm: sha256 or sha512 or SASL mechanism: gssapi, awsiam or oauthbearer                                                    |
 | sasl.aws-region                | AWS_REGION env | The AWS region for IAM SASL authentication                                                                                                     |
 | sasl.oauthbearer-token-url     |                | The url to retrieve OAuthBearer tokens from, for OAuthBearer SASL authentication                                                               |
+| sasl.oauthbearer-scopes        |                | The comma-separated scopes to use for OAuthBearer SASL authentication authentication                                                               |
 | sasl.service-name              |                | Service name when using Kerberos Auth                                                                                                          |
 | sasl.kerberos-config-path      |                | Kerberos config path                                                                                                                           |
 | sasl.realm                     |                | Kerberos realm                                                                                                                                 |

--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
             - --sasl.password={{ .Values.kafkaExporter.sasl.password }}
             - --sasl.mechanism={{ .Values.kafkaExporter.sasl.mechanism }}
             - --sasl.oauthbearer-token-url={{ .Values.kafkaExporter.sasl.oauthbearerTokenUrl }}
+            {{- if .Values.kafkaExporter.sasl.oauthbearerScopes }}
+            - --sasl.oauthbearer-scopes={{ .Values.kafkaExporter.sasl.oauthbearerScopes }}
+            {{- end }}
             {{- end }}
             {{- if .Values.kafkaExporter.tls.enabled}}
             - --tls.enabled

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -29,6 +29,7 @@ kafkaExporter:
     password: ""
     mechanism: ""
     oauthbearerTokenUrl: ""
+    oauthbearerScopes: ""
 
   tls:
     enabled: false

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -94,6 +94,7 @@ type kafkaOpts struct {
 	saslDisablePAFXFast      bool
 	saslAwsRegion            string
 	saslOAuthBearerTokenUrl  string
+	saslOAuthBearerScopes    string
 	useTLS                   bool
 	tlsServerName            string
 	tlsCAFile                string
@@ -265,6 +266,7 @@ func NewExporter(opts kafkaOpts, topicFilter string, topicExclude string, groupF
 				TokenURL:     tokenUrl,
 				ClientID:     saslUsername,
 				ClientSecret: saslPassword,
+				Scopes:       strings.Split(opts.saslOAuthBearerScopes, ","),
 			}
 			config.Net.SASL.TokenProvider = newOauthbearerTokenProvider(&oauth2Config)
 		case "plain":
@@ -833,6 +835,7 @@ func main() {
 	toFlagStringVar("sasl.password", "SASL user password.", "", &opts.saslPassword)
 	toFlagStringVar("sasl.aws-region", "The AWS region for IAM SASL authentication", os.Getenv("AWS_REGION"), &opts.saslAwsRegion)
 	toFlagStringVar("sasl.oauthbearer-token-url", "The url to retrieve OAuthBearer tokens from, for OAuthBearer SASL authentication", "", &opts.saslOAuthBearerTokenUrl)
+	toFlagStringVar("sasl.oauthbearer-scopes", "The comma-separated scopes to use for OAuthBearer SASL authentication", "", &opts.saslOAuthBearerScopes)
 	toFlagStringVar("sasl.mechanism", "SASL SCRAM SHA algorithm: sha256 or sha512 or SASL mechanism: gssapi, awsiam or oauthbearer", "", &opts.saslMechanism)
 	toFlagStringVar("sasl.service-name", "Service name when using kerberos Auth", "", &opts.serviceName)
 	toFlagStringVar("sasl.kerberos-config-path", "Kerberos config path", "", &opts.kerberosConfigPath)


### PR DESCRIPTION
This PR adds the `sasl.oauthbearer-scopes` parameter to support specifying the scopes for oauthbearer auth. This is required when connecting to Azure Event Hubs using oauth but other oauth implementations may have the same requirement.

Related issue: https://github.com/danielqsj/kafka_exporter/issues/422