### PR TITLE
Adding replicas lable to topic partition replicas metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ kafka_topic_partition_leader_is_preferred{partition="0",topic="__consumer_offset
 
 # HELP kafka_topic_partition_replicas Number of Replicas for this Topic/Partition
 # TYPE kafka_topic_partition_replicas gauge
-kafka_topic_partition_replicas{partition="0",topic="__consumer_offsets"} 3
+kafka_topic_partition_replicas{partition="0",replicas="[1 2 3]",topic="__consumer_offsets"} 3
 
 # HELP kafka_topic_partition_under_replicated_partition 1 if Topic/Partition is under Replicated
 # TYPE kafka_topic_partition_under_replicated_partition gauge

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -530,7 +530,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 				klog.Errorf("Cannot get replicas of topic %s partition %d: %v", topic, partition, err)
 			} else {
 				ch <- prometheus.MustNewConstMetric(
-					topicPartitionReplicas, prometheus.GaugeValue, float64(len(replicas)), topic, strconv.FormatInt(int64(partition), 10),
+					topicPartitionReplicas, prometheus.GaugeValue, float64(len(replicas)), topic, strconv.FormatInt(int64(partition), 10),  fmt.Sprint(replicas),
 				)
 			}
 
@@ -942,7 +942,7 @@ func setup(
 	topicPartitionReplicas = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "topic", "partition_replicas"),
 		"Number of Replicas for this Topic/Partition",
-		[]string{"topic", "partition"}, labels,
+		[]string{"topic", "partition", "replicas"}, labels,
 	)
 
 	topicPartitionInSyncReplicas = prometheus.NewDesc(


### PR DESCRIPTION
This PR adds replicas of topic partition to "kafka_topic_partition_replicas" metric under a label "replicas".

Eg:
kafka_topic_partition_replicas{partition="0",replicas="[1 2 3]",topic="__consumer_offsets"} 3



This addresses [#489 ](https://github.com/danielqsj/kafka_exporter/issues/489)