### PR TITLE
fix: do not include unavailable consumer offsets in current_offset_sum

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -785,7 +785,9 @@ func (e *Exporter) emitGroupMetrics(group *sarama.GroupDescription, broker *sara
 				continue
 			}
 			currentOffset := offsetFetchResponseBlock.Offset
-			currentOffsetSum += currentOffset
+			if currentOffset != -1 {
+				currentOffsetSum += currentOffset
+			}
 			ch <- prometheus.MustNewConstMetric(
 				consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
 			)


### PR DESCRIPTION
Kafka returns -1 when there is no committed offset for a topic-partition under a consumer group. The exporter already exposes this value in the per-partition kafka_consumergroup_current_offset metric, but the aggregate kafka_consumergroup_current_offset_sum should not add these sentinel values.

This makes current_offset_sum consistent with lag_sum, which already skips unavailable offsets instead of adding -1.