### PR TITLE
feat: add kafka_topic_partition_consumer metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Describe all topics.
 | `kafka_topic_partition_leader_is_preferred`        | 1 if Topic/Partition is using the Preferred Broker  |
 | `kafka_topic_partition_replicas`                   | Number of Replicas for this Topic/Partition         |
 | `kafka_topic_partition_under_replicated_partition` | 1 if Topic/Partition is under Replicated            |
+| `kafka_topic_partition_consumer`                   | Active consumer on topic partition (1 if assigned, 0 if the group consumes but has no active member on the partition) |
 
 **Metrics output example**
 
@@ -242,6 +243,21 @@ kafka_topic_partition_replicas{partition="0",topic="__consumer_offsets"} 3
 # HELP kafka_topic_partition_under_replicated_partition 1 if Topic/Partition is under Replicated
 # TYPE kafka_topic_partition_under_replicated_partition gauge
 kafka_topic_partition_under_replicated_partition{partition="0",topic="__consumer_offsets"} 0
+
+# HELP kafka_topic_partition_consumer Active consumer on topic partition (1 if assigned, 0 if group consumes but no active member)
+# TYPE kafka_topic_partition_consumer gauge
+kafka_topic_partition_consumer{client_id="my-client",consumergroup="my-group",consumer_id="my-client-abc",host="10.0.0.1",partition="3",topic="my-topic"} 1
+kafka_topic_partition_consumer{client_id="-",consumergroup="my-group",consumer_id="-",host="-",partition="0",topic="my-topic"} 0
+```
+
+Labels for `kafka_topic_partition_consumer`: `topic`, `partition`, `consumergroup`, `consumer_id`, `host`, `client_id`. Value **0** uses `"-"` for consumer labels when the group has a committed offset on the partition but no active member (same as `kafka-consumer-groups.sh --describe` with no active members). Requires **Describe** consumer groups. On large clusters, tighten `topic.filter` and `group.filter` to limit time series cardinality.
+
+Example PromQL:
+
+```promql
+kafka_topic_partition_consumer{topic="my-topic", consumer_id!="-"} == 1
+kafka_topic_partition_consumer{consumergroup="my-group", consumer_id="-"} == 0
+count(kafka_topic_partition_consumer{topic="my-topic", consumer_id!="-"} == 1) by (topic)
 ```
 
 ### Consumer Groups

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	namespace = "kafka"
-	clientID  = "kafka_exporter"
+	namespace             = "kafka"
+	clientID              = "kafka_exporter"
+	inactiveConsumerLabel = "-"
 )
 
 const (
@@ -55,6 +56,7 @@ var (
 	topicPartitionInSyncReplicas       *prometheus.Desc
 	topicPartitionUsesPreferredReplica *prometheus.Desc
 	topicUnderReplicatedPartition      *prometheus.Desc
+	topicPartitionConsumer             *prometheus.Desc
 	consumergroupCurrentOffset         *prometheus.Desc
 	consumergroupCurrentOffsetSum      *prometheus.Desc
 	consumergroupLag                   *prometheus.Desc
@@ -400,6 +402,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- topicPartitionInSyncReplicas
 	ch <- topicPartitionUsesPreferredReplica
 	ch <- topicUnderReplicatedPartition
+	ch <- topicPartitionConsumer
 	ch <- consumergroupCurrentOffset
 	ch <- consumergroupCurrentOffsetSum
 	ch <- consumergroupLag
@@ -650,6 +653,9 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 	// Even though we do another release below, this is fine (double release is a no-op).
 	defer pool.Release()
 
+	seenConsumerMetrics := make(map[consumerMetricKey]struct{})
+	var consumerMetricsMu sync.Mutex
+
 	// broker should be opened before calling this function
 	getConsumerGroupMetrics := func(broker *sarama.Broker) {
 		defer wg.Done()
@@ -678,7 +684,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 			}
 
 			err := pool.Submit(func() {
-				e.emitGroupMetrics(group, broker, offset, ch)
+				e.emitGroupMetrics(group, broker, offset, ch, seenConsumerMetrics, &consumerMetricsMu)
 			})
 			if err != nil {
 				klog.Errorf("Cannot submit task to pool: %v", err)
@@ -720,7 +726,90 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (e *Exporter) emitGroupMetrics(group *sarama.GroupDescription, broker *sarama.Broker, offsetMap map[string]map[int32]int64, ch chan<- prometheus.Metric) {
+type consumerMetricKey struct {
+	consumergroup string
+	topic         string
+	partition     string
+	consumerID    string
+}
+
+func normalizeConsumerHost(host string) string {
+	return strings.TrimPrefix(host, "/")
+}
+
+func (e *Exporter) tryEmitTopicPartitionConsumer(
+	ch chan<- prometheus.Metric,
+	seen map[consumerMetricKey]struct{},
+	mu *sync.Mutex,
+	topic, partition, consumergroup, consumerID, host, clientID string,
+	value float64,
+) {
+	if !e.topicFilter.MatchString(topic) || e.topicExclude.MatchString(topic) {
+		return
+	}
+	key := consumerMetricKey{
+		consumergroup: consumergroup,
+		topic:         topic,
+		partition:     partition,
+		consumerID:    consumerID,
+	}
+	mu.Lock()
+	if _, dup := seen[key]; dup {
+		mu.Unlock()
+		return
+	}
+	seen[key] = struct{}{}
+	mu.Unlock()
+
+	ch <- prometheus.MustNewConstMetric(
+		topicPartitionConsumer, prometheus.GaugeValue, value,
+		topic, partition, consumergroup, consumerID, host, clientID,
+	)
+}
+
+func (e *Exporter) emitGroupMetrics(
+	group *sarama.GroupDescription,
+	broker *sarama.Broker,
+	offsetMap map[string]map[int32]int64,
+	ch chan<- prometheus.Metric,
+	seenConsumerMetrics map[consumerMetricKey]struct{},
+	consumerMetricsMu *sync.Mutex,
+) {
+	coveredPartitions := make(map[string]map[int32]bool)
+	markCovered := func(topic string, partition int32) {
+		if coveredPartitions[topic] == nil {
+			coveredPartitions[topic] = make(map[int32]bool)
+		}
+		coveredPartitions[topic][partition] = true
+	}
+	isCovered := func(topic string, partition int32) bool {
+		return coveredPartitions[topic][partition]
+	}
+
+	if group.State == "Stable" && len(group.Members) > 0 {
+		for _, member := range group.Members {
+			if len(member.MemberAssignment) == 0 {
+				continue
+			}
+			assignment, err := member.GetMemberAssignment()
+			if err != nil {
+				klog.Errorf("Cannot get GetMemberAssignment of group member %v : %v", member, err)
+				continue
+			}
+			for topic, partitions := range assignment.Topics {
+				for _, partition := range partitions {
+					markCovered(topic, partition)
+					e.tryEmitTopicPartitionConsumer(
+						ch, seenConsumerMetrics, consumerMetricsMu,
+						topic, strconv.FormatInt(int64(partition), 10), group.GroupId,
+						member.MemberId, normalizeConsumerHost(member.ClientHost), member.ClientId,
+						1,
+					)
+				}
+			}
+		}
+	}
+
 	offsetFetchRequest := sarama.OffsetFetchRequest{ConsumerGroup: group.GroupId, Version: e.fetchOffsetVersion()}
 	if e.offsetShowAll {
 		for topic, partitions := range offsetMap {
@@ -785,6 +874,14 @@ func (e *Exporter) emitGroupMetrics(group *sarama.GroupDescription, broker *sara
 				continue
 			}
 			currentOffset := offsetFetchResponseBlock.Offset
+			if currentOffset != -1 && !isCovered(topic, partition) {
+				e.tryEmitTopicPartitionConsumer(
+					ch, seenConsumerMetrics, consumerMetricsMu,
+					topic, strconv.FormatInt(int64(partition), 10), group.GroupId,
+					inactiveConsumerLabel, inactiveConsumerLabel, inactiveConsumerLabel,
+					0,
+				)
+			}
 			currentOffsetSum += currentOffset
 			ch <- prometheus.MustNewConstMetric(
 				consumergroupCurrentOffset, prometheus.GaugeValue, float64(currentOffset), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
@@ -1014,6 +1111,12 @@ func setup(
 		prometheus.BuildFQName(namespace, "topic", "partition_under_replicated_partition"),
 		"1 if Topic/Partition is under Replicated",
 		[]string{"topic", "partition"}, labels,
+	)
+
+	topicPartitionConsumer = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "topic", "partition_consumer"),
+		"Active consumer on topic partition (1 if assigned, 0 if group consumes but no active member)",
+		[]string{"topic", "partition", "consumergroup", "consumer_id", "host", "client_id"}, labels,
 	)
 
 	consumergroupCurrentOffset = prometheus.NewDesc(


### PR DESCRIPTION
Expose a per topic-partition consumer assignment metric: value 1 for an active member of a stable consumer group, and value 0 (with "-" labels) when the group has a committed offset on the partition but no active member. Metrics are deduplicated across brokers/groups and filtered by the existing topic filters.