### PR TITLE
Wait for the metric appender before reading the collected metrics

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -435,13 +435,18 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) collectChans(quit chan struct{}) {
 	original := make(chan prometheus.Metric)
 	container := make([]prometheus.Metric, 0, 100)
+	drained := make(chan struct{})
 	go func() {
+		defer close(drained)
 		for metric := range original {
 			container = append(container, metric)
 		}
 	}()
 	e.collect(original)
 	close(original)
+	// wait for the appender to finish: a send on original returns before the receiver has
+	// appended it, so reading container without this drops the last metrics of the scrape
+	<-drained
 	// Lock to avoid modification on the channel slice
 	e.sgMutex.Lock()
 	for _, ch := range e.sgChans {


### PR DESCRIPTION
## What

`collectChans` loses the metrics emitted at the end of a scrape.

It starts a goroutine that appends every metric from the collect channel into a `container` slice, then reads that slice as soon as `collect` returns and the channel is closed. Closing the channel does not wait for the receiver: a send completes once the value is *received*, but the `append` that follows it may not have happened yet. So the main goroutine can read `container` while the appender is still writing to it.

This is a data race, and it silently drops data.

## Evidence

Go's race detector flags it directly (`kafka_exporter.go:448` read vs `:440` write in the appender goroutine):

```
WARNING: DATA RACE
Read at 0x00c00020a5d0 by goroutine 34:
  main.(*Exporter).collectChans()
      kafka_exporter.go:448
Previous write at 0x00c00020a5d0 by goroutine 35:
  main.(*Exporter).collectChans.func1()
      kafka_exporter.go:440
```

It is observable in normal operation. Against a 3-broker cluster with three consumer groups, scraping `/metrics` 30 times on master:

| | scrapes missing a `kafka_consumergroup_lag_sum` series |
|---|---|
| master | 3 / 30 |
| with this fix | **0 / 30** |

The dropped series lands on a random group each time, since it is whichever metric happened to be emitted last. `kafka_consumergroup_lag_sum` is the usual victim because it is emitted last per topic — a Prometheus target intermittently missing a lag series looks like a broken exporter, not a race.

Race detector is clean with the fix.

## Fix

Signal completion from the appender goroutine and wait for it before reading the container. Five lines, no behaviour change beyond not losing metrics.

## Reproducing

```bash
go build -race -o kafka_exporter_race .
./kafka_exporter_race --kafka.server=localhost:19092 --web.listen-address=:19311 &
for i in $(seq 1 5); do curl -s -o /dev/null localhost:19311/metrics; sleep 1; done
# race detector fires on master, clean with this fix

# and the user-visible symptom:
for i in $(seq 1 30); do
  curl -s localhost:19311/metrics | grep -c '^kafka_consumergroup_lag_sum{'
done   # varies on master, constant with this fix
```
