### PR TITLE
fix: race condition between collectChans and its metric collecting goroutine

### DIFF
--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -435,13 +435,16 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) collectChans(quit chan struct{}) {
 	original := make(chan prometheus.Metric)
 	container := make([]prometheus.Metric, 0, 100)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		for metric := range original {
 			container = append(container, metric)
 		}
 	}()
 	e.collect(original)
 	close(original)
+	<-done
 	// Lock to avoid modification on the channel slice
 	e.sgMutex.Lock()
 	for _, ch := range e.sgChans {


### PR DESCRIPTION
This small PR fixes a race condition in the goroutine that collect the metrics.